### PR TITLE
[feature]: User API 구현

### DIFF
--- a/src/main/java/com/splanet/splanet/config/SecurityConfig.java
+++ b/src/main/java/com/splanet/splanet/config/SecurityConfig.java
@@ -27,7 +27,6 @@ public class SecurityConfig {
     http
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/admin").authenticated()
                     .anyRequest().permitAll()
             )
             .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/splanet/splanet/core/BaseEntity.java
+++ b/src/main/java/com/splanet/splanet/core/BaseEntity.java
@@ -14,7 +14,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @Getter
 @Setter(value = AccessLevel.PROTECTED)
 @MappedSuperclass

--- a/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
+++ b/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     ACCESS_DENIED("권한이 없습니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZED("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
     ALREADY_CANCELED("이미 취소된 구독입니다.", HttpStatus.BAD_REQUEST),
-    SUBSCRIPSTION_NOT_FOUND("활성화된 구독을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    SUBSCRIPSTION_NOT_FOUND("활성화된 구독을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND("유저가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/splanet/splanet/core/exception/ErrorResponse.java
+++ b/src/main/java/com/splanet/splanet/core/exception/ErrorResponse.java
@@ -1,5 +1,8 @@
 package com.splanet.splanet.core.exception;
 
+import lombok.Getter;
+
+@Getter
 public class ErrorResponse {
     private String message;
     private int status;

--- a/src/main/java/com/splanet/splanet/oauth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/splanet/splanet/oauth/JwtAuthenticationFilter.java
@@ -1,5 +1,9 @@
 package com.splanet.splanet.oauth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.splanet.splanet.core.exception.BusinessException;
+import com.splanet.splanet.core.exception.ErrorResponse;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,25 +27,64 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
           throws ServletException, IOException {
+    String requestURI = request.getRequestURI();
 
-    String token = resolveToken(request);
+    if (isSwaggerPath(requestURI)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
 
-    if (token != null && jwtTokenProvider.validateToken(token)) {
-
-      Long userId = jwtTokenProvider.getUserIdFromToken(token);
-
-      UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userId, null, null);
-      SecurityContextHolder.getContext().setAuthentication(auth);
+    if (isApiPath(requestURI)) {
+      handleTokenAuthentication(request, response);
     }
 
     filterChain.doFilter(request, response);
   }
 
+  private void handleTokenAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String token = resolveToken(request);
+
+    if (token == null) {
+      sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "토큰이 없습니다.");
+      return;
+    }
+
+    try {
+      if (jwtTokenProvider.validateToken(token)) {
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userId, null, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+      } else {
+        sendErrorResponse(response, HttpServletResponse.SC_FORBIDDEN, "유효하지 않은 토큰입니다.");
+      }
+    } catch (JwtException e) {
+      sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    } catch (BusinessException e) {
+      sendErrorResponse(response, e.getErrorCode().getStatus().value(), e.getMessage());
+    } catch (Exception e) {
+      sendErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    }
+  }
+
+  private boolean isSwaggerPath(String requestURI) {
+    return requestURI.startsWith("/swagger-ui/") || requestURI.startsWith("/v3/api-docs/") ||
+            requestURI.startsWith("/swagger-resources/") || requestURI.startsWith("/webjars/");
+  }
+
+  private boolean isApiPath(String requestURI) {
+    return requestURI.startsWith("/api/");
+  }
+
+  private void sendErrorResponse(HttpServletResponse response, int status, String message) throws IOException {
+    response.setStatus(status);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    ErrorResponse errorResponse = new ErrorResponse(message, status);
+    new ObjectMapper().writeValue(response.getWriter(), errorResponse);
+  }
+
   private String resolveToken(HttpServletRequest request) {
     String bearerToken = request.getHeader("Authorization");
-    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-      return bearerToken.substring(7);
-    }
-    return null;
+    return (bearerToken != null && bearerToken.startsWith("Bearer ")) ? bearerToken.substring(7) : null;
   }
 }

--- a/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -35,17 +35,22 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 
     String nickname = (String) properties.get("nickname");
     String profileImage = (String) properties.get("profile_image_url");
-    String email = (String) kakaoAccount.get("email");
 
     Optional<User> existingUser = userRepository.findByNickname(nickname);
+    User user;
+
     if (existingUser.isEmpty()) {
-      User newUser = User.builder()
+      user = User.builder()
               .nickname(nickname)
               .profileImage(profileImage)
               .build();
-      userRepository.save(newUser);
+      userRepository.save(user);
+    } else {
+      user = existingUser.get();
     }
-    String token = jwtTokenProvider.createToken(authentication);
+
+    String token = jwtTokenProvider.createToken(user.getId(), user.getNickname());
+
     String redirectUrl = "http://localhost:5173?token=" + token;
     response.sendRedirect(redirectUrl);
   }

--- a/src/main/java/com/splanet/splanet/user/controller/UserController.java
+++ b/src/main/java/com/splanet/splanet/user/controller/UserController.java
@@ -1,0 +1,67 @@
+package com.splanet.splanet.user.controller;
+
+import com.splanet.splanet.user.dto.UserResponseDto;
+import com.splanet.splanet.user.dto.UserUpdateRequestDto;
+import com.splanet.splanet.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "Users", description = "유저 정보 관련 API")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    @Operation(summary = "유저 정보 조회", description = "토큰을 사용하여 현재 로그인한 유저의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 반환되었습니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    public ResponseEntity<UserResponseDto> getUserInfo(
+            @AuthenticationPrincipal Long userId) {
+        UserResponseDto userResponse = userService.getUserById(userId);
+        return ResponseEntity.ok(userResponse);
+    }
+
+    @PutMapping("/me")
+    @Operation(summary = "유저 정보 수정", description = "유저의 닉네임, 프로필 이미지, 프리미엄 여부를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 수정되었습니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청. 필드 값이 잘못되었습니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    public ResponseEntity<UserResponseDto> updateUserInfo(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UserUpdateRequestDto requestDto) {
+        UserResponseDto updatedUser = userService.updateUserInfo(userId, requestDto);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @DeleteMapping("/me")
+    @Operation(summary = "유저 삭제", description = "현재 로그인한 유저의 계정을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저가 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    public ResponseEntity<Void> deleteUser(
+            @AuthenticationPrincipal Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/splanet/splanet/user/dto/UserResponseDto.java
+++ b/src/main/java/com/splanet/splanet/user/dto/UserResponseDto.java
@@ -1,0 +1,17 @@
+package com.splanet.splanet.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserResponseDto {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private Boolean isPremium;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/splanet/splanet/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/splanet/splanet/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.splanet.splanet.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserUpdateRequestDto {
+    private String nickname;
+    private String profileImage;
+    private Boolean isPremium;
+}

--- a/src/main/java/com/splanet/splanet/user/entity/User.java
+++ b/src/main/java/com/splanet/splanet/user/entity/User.java
@@ -15,7 +15,7 @@ import lombok.experimental.SuperBuilder;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class User extends BaseEntity {
 
   @NotBlank

--- a/src/main/java/com/splanet/splanet/user/service/UserService.java
+++ b/src/main/java/com/splanet/splanet/user/service/UserService.java
@@ -1,0 +1,59 @@
+package com.splanet.splanet.user.service;
+
+import com.splanet.splanet.user.dto.UserResponseDto;
+import com.splanet.splanet.user.dto.UserUpdateRequestDto;
+import com.splanet.splanet.user.entity.User;
+import com.splanet.splanet.user.repository.UserRepository;
+import com.splanet.splanet.core.exception.BusinessException;
+import com.splanet.splanet.core.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserResponseDto getUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return toUserResponseDto(user);
+    }
+
+    @Transactional
+    public UserResponseDto updateUserInfo(Long userId, UserUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        User updatedUser = user.toBuilder()
+                .nickname(requestDto.getNickname())
+                .profileImage(requestDto.getProfileImage())
+                .isPremium(requestDto.getIsPremium())
+                .build();
+
+        userRepository.save(updatedUser);
+
+        return toUserResponseDto(updatedUser);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        userRepository.delete(user);
+    }
+
+    private UserResponseDto toUserResponseDto(User user) {
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .isPremium(user.getIsPremium())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/test/java/com/splanet/splanet/user/service/UserServiceTest.java
+++ b/src/test/java/com/splanet/splanet/user/service/UserServiceTest.java
@@ -1,0 +1,148 @@
+package com.splanet.splanet.user.service;
+
+import com.splanet.splanet.core.exception.BusinessException;
+import com.splanet.splanet.core.exception.ErrorCode;
+import com.splanet.splanet.user.dto.UserResponseDto;
+import com.splanet.splanet.user.dto.UserUpdateRequestDto;
+import com.splanet.splanet.user.entity.User;
+import com.splanet.splanet.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 유저_조회_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .nickname("라이언")
+                .profileImage("profile.png")
+                .isPremium(true)
+                .build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        UserResponseDto result = userService.getUserById(userId);
+
+        // then
+        assertThat(result.getId()).isEqualTo(userId);
+        assertThat(result.getNickname()).isEqualTo("라이언");
+        assertThat(result.getProfileImage()).isEqualTo("profile.png");
+        assertThat(result.getIsPremium()).isTrue();
+    }
+
+    @Test
+    void 유저_조회_없는유저() {
+        // given
+        Long userId = 1L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserById(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 유저_정보_수정_성공() {
+        // given
+        Long userId = 1L;
+        User existingUser = User.builder()
+                .id(userId)
+                .nickname("라이언")
+                .profileImage("oldProfile.png")
+                .isPremium(false)
+                .build();
+
+        UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+                .nickname("춘식이")
+                .profileImage("newProfile.png")
+                .isPremium(true)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(existingUser));
+
+        // when
+        UserResponseDto updatedUser = userService.updateUserInfo(userId, requestDto);
+
+        // then
+        assertThat(updatedUser.getNickname()).isEqualTo("춘식이");
+        assertThat(updatedUser.getProfileImage()).isEqualTo("newProfile.png");
+        assertThat(updatedUser.getIsPremium()).isTrue();
+
+        // verify that save method was called
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void 유저_정보_수정_없는유저() {
+        // given
+        Long userId = 1L;
+        UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+                .nickname("춘식이")
+                .profileImage("newProfile.png")
+                .isPremium(true)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(userId, requestDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 유저_삭제_성공() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .nickname("라이언")
+                .profileImage("profile.png")
+                .isPremium(true)
+                .build();
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        userService.deleteUser(userId);
+
+        // then
+        verify(userRepository).delete(user);
+    }
+
+    @Test
+    void 유저_삭제_없는유저() {
+        // given
+        Long userId = 1L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteUser(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 📄요약

> User API를 구현한다.

## 🖋️작업 내용

- [x] 유저 조회
- [x] 유저 삭제
- [x] 유저 수정

## 📷스크린샷
<img width="602" alt="image" src="https://github.com/user-attachments/assets/118d106a-f917-4010-b1c8-3c2a2a4cc0e4">

로그인 진행 후 헤더에 토큰 넣습니다.


<img width="600" alt="image" src="https://github.com/user-attachments/assets/c901d86b-cdc8-4a00-8718-ed2bea39ff13">

api 동작 확인합니다.


## ❗참고 사항
로그인은 직접 하셔야합니다. 그리고 스웨거에서 Authorize 에서 토큰 집어넣으면 됩니다. 
토큰이 없다면 
```
{
  "message": "토큰이 없습니다.",
  "status": 401
}
```

를 출력합니다.

## 🔗이슈
close #22 
