### PR TITLE
[refactor]: 구독, 결제, 댓글 엔티티 연관관계 설정

### DIFF
--- a/src/main/java/com/splanet/splanet/subscription/entity/Subscription.java
+++ b/src/main/java/com/splanet/splanet/subscription/entity/Subscription.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 public class Subscription extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToOne(mappedBy = "subscription", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/splanet/splanet/subscription/entity/Subscription.java
+++ b/src/main/java/com/splanet/splanet/subscription/entity/Subscription.java
@@ -1,6 +1,8 @@
 package com.splanet.splanet.subscription.entity;
 
 import com.splanet.splanet.core.BaseEntity;
+import com.splanet.splanet.payment.entity.Payment;
+import com.splanet.splanet.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -15,8 +17,12 @@ import java.time.LocalDateTime;
 @Entity
 public class Subscription extends BaseEntity {
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @OneToOne(mappedBy = "subscription", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    private Payment payment;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")

--- a/src/main/java/com/splanet/splanet/user/entity/User.java
+++ b/src/main/java/com/splanet/splanet/user/entity/User.java
@@ -24,12 +24,6 @@ public class User extends BaseEntity {
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
   private Subscription subscription;
 
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Comment> comments;
-
-  @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Comment> writtenComments;
-
   @NotBlank
   @Size(max = 100)
   @Column(name = "nickname", nullable = false, length = 100, unique = true)

--- a/src/main/java/com/splanet/splanet/user/entity/User.java
+++ b/src/main/java/com/splanet/splanet/user/entity/User.java
@@ -2,10 +2,8 @@ package com.splanet.splanet.user.entity;
 
 import com.splanet.splanet.comment.entity.Comment;
 import com.splanet.splanet.core.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
+import com.splanet.splanet.subscription.entity.Subscription;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -23,6 +21,15 @@ import java.util.List;
 @SuperBuilder(toBuilder = true)
 public class User extends BaseEntity {
 
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+  private Subscription subscription;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> comments;
+
+  @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> writtenComments;
+
   @NotBlank
   @Size(max = 100)
   @Column(name = "nickname", nullable = false, length = 100, unique = true)
@@ -38,11 +45,5 @@ public class User extends BaseEntity {
   @Builder.Default
   @Column(name = "is_premium")
   private Boolean isPremium = false;
-
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Comment> comments;
-
-  @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Comment> writtenComments;
 
 }

--- a/src/main/java/com/splanet/splanet/user/entity/User.java
+++ b/src/main/java/com/splanet/splanet/user/entity/User.java
@@ -1,8 +1,11 @@
 package com.splanet.splanet.user.entity;
 
+import com.splanet.splanet.comment.entity.Comment;
 import com.splanet.splanet.core.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -10,6 +13,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.util.List;
 
 @Getter
 @Entity
@@ -33,5 +38,11 @@ public class User extends BaseEntity {
   @Builder.Default
   @Column(name = "is_premium")
   private Boolean isPremium = false;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> comments;
+
+  @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Comment> writtenComments;
 
 }

--- a/src/test/java/com/splanet/splanet/subscription/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/splanet/splanet/subscription/service/SubscriptionServiceTest.java
@@ -5,12 +5,19 @@ import com.splanet.splanet.subscription.dto.SubscriptionResponse;
 import com.splanet.splanet.subscription.entity.Subscription;
 import com.splanet.splanet.subscription.repository.SubscriptionRepository;
 import com.splanet.splanet.core.exception.BusinessException;
-import com.splanet.splanet.core.exception.ErrorCode;
+import com.splanet.splanet.user.entity.User;
+import com.splanet.splanet.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,104 +25,129 @@ import static org.mockito.Mockito.*;
 
 class SubscriptionServiceTest {
 
-    private SubscriptionRepository subscriptionRepository;
+    @InjectMocks
     private SubscriptionService subscriptionService;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User mockedUser;
+    private Subscription mockedSubscription;
 
     @BeforeEach
     void setUp() {
-        subscriptionRepository = Mockito.mock(SubscriptionRepository.class);
-        subscriptionService = new SubscriptionService(subscriptionRepository);
+        MockitoAnnotations.openMocks(this);
+        // 모킹된 User 객체 생성
+        mockedUser = mock(User.class);
+        when(mockedUser.getId()).thenReturn(1L);
+
+        // 모킹된 Subscription 객체 생성
+        mockedSubscription = mock(Subscription.class);
+        when(mockedSubscription.getUser()).thenReturn(mockedUser);
+        when(mockedSubscription.getStatus()).thenReturn(Subscription.Status.ACTIVE);
+        when(mockedSubscription.getStartDate()).thenReturn(LocalDateTime.now());
+        when(mockedSubscription.getEndDate()).thenReturn(LocalDateTime.now().plusMonths(1));
     }
 
     @Test
     void 구독조회성공() {
-        Long userId = 1L;
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.getId()).thenReturn(123L);
-        when(subscription.getType()).thenReturn(Subscription.Type.MONTHLY);
-        when(subscription.getStatus()).thenReturn(Subscription.Status.ACTIVE);
-        when(subscription.getStartDate()).thenReturn(LocalDateTime.now());
-        when(subscription.getEndDate()).thenReturn(LocalDateTime.now().plusMonths(1));
+        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(any(Long.class), any(Subscription.Status.class)))
+                .thenReturn(Optional.of(mockedSubscription));
 
-        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(userId, Subscription.Status.ACTIVE))
-                .thenReturn(java.util.Optional.of(subscription));
+        ResponseEntity<SubscriptionResponse> response = subscriptionService.getSubscription(1L);
 
-        SubscriptionResponse response = subscriptionService.getSubscription(userId).getBody();
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals("구독 정보가 성공적으로 조회되었습니다.", response.getBody().getMessage());
+        assertNotNull(response.getBody().getSubscription());
 
-        assertNotNull(response);
-        assertEquals("구독 정보가 성공적으로 조회되었습니다.", response.getMessage());
-        assertEquals(123L, response.getSubscription().getId());
+        SubscriptionResponse.SubscriptionDetails details = response.getBody().getSubscription();
+        assertEquals(mockedSubscription.getId(), details.getId());
+        assertEquals(mockedSubscription.getStartDate().toString(), details.getStartDate());
+        assertEquals(mockedSubscription.getEndDate().toString(), details.getEndDate());
     }
 
     @Test
-    void 구독조회실패_구독미존재() {
-        Long userId = 1L;
+    void 구독조회실패_사용자미인증() {
+        assertThrows(BusinessException.class, () -> subscriptionService.getSubscription(null));
+    }
 
-        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(userId, Subscription.Status.ACTIVE))
-                .thenReturn(java.util.Optional.empty());
+    @Test
+    void 구독조회실패_구독미발견() {
+        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(any(Long.class), any(Subscription.Status.class)))
+                .thenReturn(Optional.empty());
 
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
-            subscriptionService.getSubscription(userId);
-        });
-
-        assertEquals(ErrorCode.SUBSCRIPSTION_NOT_FOUND, exception.getErrorCode());
+        assertThrows(BusinessException.class, () -> subscriptionService.getSubscription(1L));
     }
 
     @Test
     void 구독취소성공() {
-        Long userId = 1L;
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.getId()).thenReturn(123L);
-        when(subscription.getUserId()).thenReturn(userId);
-        when(subscription.getStatus()).thenReturn(Subscription.Status.ACTIVE);
+        // Given
+        Subscription mockedSubscription = mock(Subscription.class);
+        when(mockedSubscription.getStatus()).thenReturn(Subscription.Status.ACTIVE);
+        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(any(Long.class), any(Subscription.Status.class)))
+                .thenReturn(Optional.of(mockedSubscription));
 
-        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(userId, Subscription.Status.ACTIVE))
-                .thenReturn(java.util.Optional.of(subscription));
+        // When
+        ResponseEntity<String> response = subscriptionService.cancelSubscription(1L);
 
-        subscriptionService.cancelSubscription(userId);
+        // Then
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("{\"message\": \"구독이 성공적으로 취소되었습니다.\"}", response.getBody());
 
-        verify(subscriptionRepository, times(1)).save(subscription);
-        verify(subscription).cancel();  // cancel 메소드 호출 확인
+        verify(mockedSubscription, times(1)).cancel(); // cancel 메소드가 호출되었는지 확인
+
+        verify(subscriptionRepository, times(1)).save(mockedSubscription);
+
+        when(mockedSubscription.getStatus()).thenReturn(Subscription.Status.CANCELED); // 상태를 CANCELED로 설정
+        assertEquals(Subscription.Status.CANCELED, mockedSubscription.getStatus());
+    }
+
+    @Test
+    void 구독취소실패_사용자미인증() {
+        assertThrows(BusinessException.class, () -> subscriptionService.cancelSubscription(null));
     }
 
     @Test
     void 구독취소실패_이미취소됨() {
-        Long userId = 1L;
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.getId()).thenReturn(123L);
-        when(subscription.getUserId()).thenReturn(userId);
-        when(subscription.getStatus()).thenReturn(Subscription.Status.CANCELED);
+        when(mockedSubscription.getStatus()).thenReturn(Subscription.Status.CANCELED);
+        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(any(Long.class), any(Subscription.Status.class)))
+                .thenReturn(Optional.of(mockedSubscription));
 
-        when(subscriptionRepository.findTopByUserIdAndStatusOrderByStartDateDesc(userId, Subscription.Status.ACTIVE))
-                .thenReturn(java.util.Optional.of(subscription));
-
-        BusinessException exception = assertThrows(BusinessException.class, () -> {
-            subscriptionService.cancelSubscription(userId);
-        });
-
-        assertEquals(ErrorCode.ALREADY_CANCELED, exception.getErrorCode());
+        assertThrows(BusinessException.class, () -> subscriptionService.cancelSubscription(1L));
     }
 
     @Test
-    void 구독하기성공() {
-        Long userId = 1L;
+    void 구독성공() {
         SubscriptionRequest request = new SubscriptionRequest();
         request.setType(Subscription.Type.MONTHLY);
 
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.getId()).thenReturn(123L);
-        when(subscription.getUserId()).thenReturn(userId);
-        when(subscription.getType()).thenReturn(Subscription.Type.MONTHLY);
-        when(subscription.getStatus()).thenReturn(Subscription.Status.ACTIVE);
-        when(subscription.getStartDate()).thenReturn(LocalDateTime.now());
-        when(subscription.getEndDate()).thenReturn(LocalDateTime.now().plusMonths(1));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockedUser));
+        when(subscriptionRepository.save(any(Subscription.class))).thenReturn(mockedSubscription);
 
-        when(subscriptionRepository.save(any(Subscription.class))).thenReturn(subscription);
+        ResponseEntity<SubscriptionResponse> response = subscriptionService.subscribe(1L, request);
 
-        SubscriptionResponse response = subscriptionService.subscribe(userId, request).getBody();
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals("구독이 성공적으로 구매되었습니다.", response.getBody().getMessage());
 
-        assertNotNull(response);
-        assertEquals("구독이 성공적으로 구매되었습니다.", response.getMessage());
-        assertEquals(123L, response.getSubscription().getId());
+        ArgumentCaptor<Subscription> captor = ArgumentCaptor.forClass(Subscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        Subscription savedSubscription = captor.getValue();
+        assertEquals(mockedUser, savedSubscription.getUser()); // Compare with the mocked user
+        assertEquals(Subscription.Status.ACTIVE, savedSubscription.getStatus());
+    }
+
+    @Test
+    void 구독실패_사용자미발견() {
+        SubscriptionRequest request = new SubscriptionRequest();
+        request.setType(Subscription.Type.MONTHLY);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(BusinessException.class, () -> subscriptionService.subscribe(1L, request));
     }
 }


### PR DESCRIPTION
## 📄요약

> 구독, 결제, 댓글 엔티티 연관관계 설정했습니다.

## 🖋️작업 내용

- [x]  comment
- [x] subcription
- [x] payment
- [x] user
- [x] 테스트코드 수정

## 📷스크린샷
![image](https://github.com/user-attachments/assets/409a7285-f5eb-4801-b4d4-80b1f3feaf2f)


## ❗참고 사항


## 🔗이슈
close #41
