### PR TITLE
[refactor]: 5주차 피드백 반영

### DIFF
--- a/src/main/java/com/splanet/splanet/comment/controller/CommentApi.java
+++ b/src/main/java/com/splanet/splanet/comment/controller/CommentApi.java
@@ -1,0 +1,78 @@
+package com.splanet.splanet.comment.controller;
+
+import com.splanet.splanet.comment.dto.CommentRequest;
+import com.splanet.splanet.comment.dto.CommentResponse;
+import com.splanet.splanet.core.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/comments")
+@Tag(name = "Comments", description = "댓글 관련 API")
+public interface CommentApi {
+
+    @GetMapping("/{user_id}")
+    @Operation(summary = "댓글 조회", description = "특정 사용자의 댓글 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "특정 사용자에게 달린 댓글이 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 유저 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<List<CommentResponse>> getComments(
+            @Parameter(description = "인증된 유저의 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "댓글을 조회할 유저의 ID", required = true) @PathVariable("user_id") Long userIdPath);
+
+    @PostMapping
+    @Operation(summary = "댓글 작성", description = "댓글을 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 작성되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 유저 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<String> createComment(
+            @Parameter(description = "인증된 유저의 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "댓글 작성 요청 정보", required = true) @RequestBody CommentRequest request);
+
+    @PutMapping("/{comment_id}")
+    @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 수정되었습니다.",
+                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 댓글 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<String> updateComment(
+            @Parameter(description = "인증된 유저의 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "수정할 댓글 ID", required = true) @PathVariable("comment_id") Long commentId,
+            @Parameter(description = "댓글 수정 요청 정보", required = true) @RequestBody CommentRequest request);
+
+    @DeleteMapping("/{comment_id}")
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 삭제되었습니다.",
+                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 댓글 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<String> deleteComment(
+            @Parameter(description = "인증된 유저의 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "삭제할 댓글 ID", required = true) @PathVariable("comment_id") Long commentId);
+}

--- a/src/main/java/com/splanet/splanet/comment/controller/CommentController.java
+++ b/src/main/java/com/splanet/splanet/comment/controller/CommentController.java
@@ -3,104 +3,38 @@ package com.splanet.splanet.comment.controller;
 import com.splanet.splanet.comment.dto.CommentRequest;
 import com.splanet.splanet.comment.dto.CommentResponse;
 import com.splanet.splanet.comment.service.CommentService;
-import com.splanet.splanet.core.exception.ErrorResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/comment")
 @RequiredArgsConstructor
-@Tag(name = "Comments", description = "댓글 관련 API")
-public class CommentController {
+public class CommentController implements CommentApi {
 
     private final CommentService commentService;
 
-    @GetMapping("/{user_id}")
-    @Operation(summary = "댓글 조회", description = "특정 사용자의 댓글 목록을 조회 합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "특정 사용자에게 달린 댓글이 성공적으로 조회되었습니다.",
-                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 친구 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<List<CommentResponse>> getComments(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable("user_id") Long userIdPath) {
+    @Override
+    public ResponseEntity<List<CommentResponse>> getComments(Long userId, Long userIdPath) {
         List<CommentResponse> comments = commentService.getComments(userIdPath);
         return ResponseEntity.ok(comments);
     }
 
-    @PostMapping
-    @Operation(summary = "댓글 작성", description = "댓글을 작성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 작성되었습니다."),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 유저 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<String> createComment(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody CommentRequest request) {
+    @Override
+    public ResponseEntity<String> createComment(Long userId, CommentRequest request) {
         commentService.createComment(userId, request);
-        return ResponseEntity.status(HttpStatus.OK).body("댓글이 성공적으로 작성되었습니다.");
+        return ResponseEntity.ok("댓글이 성공적으로 작성되었습니다.");
     }
 
-    @PutMapping("/{comment_id}")
-    @Operation(summary = "댓글 수정", description = "댓글을 수정 합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "댓글이 성공적으로 수정되었습니다.",
-                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 댓글 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<String> updateComment(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable("comment_id") Long commentId,
-            @RequestBody CommentRequest request) {
+    @Override
+    public ResponseEntity<String> updateComment(Long userId, Long commentId, CommentRequest request) {
         commentService.updateComment(commentId, request, userId);
         return ResponseEntity.ok("댓글이 성공적으로 수정되었습니다.");
     }
 
-    @DeleteMapping("/{comment_id}")
-    @Operation(summary = "댓글 삭제", description = "댓글을 삭제 합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "댓글이 성공적으로 삭제되었습니다.",
-                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 댓글 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<String> deleteComment(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable("comment_id") Long commentId) {
+    @Override
+    public ResponseEntity<String> deleteComment(Long userId, Long commentId) {
         commentService.deleteComment(commentId, userId);
         return ResponseEntity.ok("댓글이 성공적으로 삭제되었습니다.");
     }

--- a/src/main/java/com/splanet/splanet/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/splanet/splanet/core/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.splanet.splanet.core.exception;
 
+import com.splanet.splanet.core.exception.ResponseConstants;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -22,23 +24,22 @@ public class GlobalExceptionHandler {
                 .stream()
                 .map(violation -> violation.getMessage())
                 .findFirst()
-                .orElse("유효성 검사에 실패하였습니다.");
+                .orElse(ResponseConstants.ErrorMessage.VALIDATION_ERROR);
 
-        ErrorResponse response = new ErrorResponse(errorMessage, 400);
-        return new ResponseEntity<>(response, org.springframework.http.HttpStatus.BAD_REQUEST);
+        ErrorResponse response = new ErrorResponse(errorMessage, ResponseConstants.StatusCode.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     protected ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
         String errorMessage = ex.getMostSpecificCause().getMessage();
 
-        // 닉네임 중복에 대한 처리
         if (errorMessage.contains("nickname")) {
-            ErrorResponse response = new ErrorResponse("닉네임이 중복되었습니다.", 400);
-            return new ResponseEntity<>(response, org.springframework.http.HttpStatus.BAD_REQUEST);
+            ErrorResponse response = new ErrorResponse(ResponseConstants.ErrorMessage.DUPLICATE_NICKNAME, ResponseConstants.StatusCode.BAD_REQUEST);
+            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
         }
 
-        ErrorResponse response = new ErrorResponse("입력값이 유효하지 않습니다.", 400);
-        return new ResponseEntity<>(response, org.springframework.http.HttpStatus.BAD_REQUEST);
+        ErrorResponse response = new ErrorResponse(ResponseConstants.ErrorMessage.INVALID_INPUT, ResponseConstants.StatusCode.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/splanet/splanet/core/exception/ResponseConstants.java
+++ b/src/main/java/com/splanet/splanet/core/exception/ResponseConstants.java
@@ -1,0 +1,17 @@
+package com.splanet.splanet.core.exception;
+
+public class ResponseConstants {
+
+    public static class ErrorMessage {
+        public static final String VALIDATION_ERROR = "유효성 검사에 실패하였습니다.";
+        public static final String DUPLICATE_NICKNAME = "닉네임이 중복되었습니다.";
+        public static final String INVALID_INPUT = "입력값이 유효하지 않습니다.";
+    }
+
+    public static class StatusCode {
+        public static final int BAD_REQUEST = 400;
+        public static final int UNAUTHORIZED = 401;
+        public static final int NOT_FOUND = 404;
+        public static final int INTERNAL_SERVER_ERROR = 500;
+    }
+}

--- a/src/main/java/com/splanet/splanet/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/splanet/splanet/jwt/JwtTokenProvider.java
@@ -44,11 +44,12 @@ public class JwtTokenProvider {
   }
 
 
-  public String createRefreshToken() {
+  public String createRefreshToken(Long userId) {
     Date now = new Date();
     Date expiryDate = new Date(now.getTime() + REFRESH_TOKEN_VALIDITY_IN_MILLISECONDS);
 
     return Jwts.builder()
+            .claim("userId", userId)
             .setIssuedAt(now)
             .setExpiration(expiryDate)
             .signWith(SignatureAlgorithm.HS256, secretKey)

--- a/src/main/java/com/splanet/splanet/jwt/controller/TokenApi.java
+++ b/src/main/java/com/splanet/splanet/jwt/controller/TokenApi.java
@@ -1,0 +1,50 @@
+package com.splanet.splanet.jwt.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/token")
+@Tag(name = "Token", description = "토큰 관련 API")
+public interface TokenApi {
+
+    @PostMapping("/issue")
+    @Operation(summary = "테스트 유저 토큰 발급", description = "테스트용 유저에게 JWT 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰이 성공적으로 발급되었습니다.",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<String> issueToken(
+            @Parameter(description = "유저 ID", required = true) @RequestParam Long userId);
+
+    @PostMapping("/refresh")
+    @Operation(summary = "리프레시 토큰을 통해 액세스 토큰 재발급", description = "유효한 리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "액세스 토큰이 성공적으로 재발급되었습니다.",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<String> refreshAccessToken(
+            @Parameter(description = "리프레시 토큰", required = true) @RequestParam String refreshToken,
+            @Parameter(description = "디바이스 ID", required = true) @RequestParam String deviceId);
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "리프레시 토큰 삭제", description = "리프레시 토큰을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리프레시 토큰이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<Void> deleteRefreshToken(
+            @Parameter(description = "유저 ID", required = true) @RequestParam Long userId,
+            @Parameter(description = "디바이스 ID", required = true) @RequestParam String deviceId);
+}

--- a/src/main/java/com/splanet/splanet/jwt/controller/TokenController.java
+++ b/src/main/java/com/splanet/splanet/jwt/controller/TokenController.java
@@ -46,8 +46,9 @@ public class TokenController {
             @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
     })
-    public ResponseEntity<String> refreshAccessToken(@RequestParam String refreshToken) {
-        String newAccessToken = tokenService.regenerateAccessToken(refreshToken);
+    public ResponseEntity<String> refreshAccessToken(@RequestParam String refreshToken,
+                                                     @RequestParam String deviceId) {
+        String newAccessToken = tokenService.regenerateAccessToken(refreshToken, deviceId);
         return ResponseEntity.ok(newAccessToken);
     }
 
@@ -58,8 +59,8 @@ public class TokenController {
             @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
     })
-    public ResponseEntity<Void> deleteRefreshToken(@RequestParam String refreshToken) {
-        tokenService.deleteRefreshToken(refreshToken);
+    public ResponseEntity<Void> deleteRefreshToken(@RequestParam Long userId, @RequestParam String deviceId) {
+        tokenService.deleteRefreshToken(userId, deviceId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/splanet/splanet/jwt/controller/TokenController.java
+++ b/src/main/java/com/splanet/splanet/jwt/controller/TokenController.java
@@ -4,62 +4,33 @@ import com.splanet.splanet.jwt.JwtTokenProvider;
 import com.splanet.splanet.jwt.service.TokenService;
 import com.splanet.splanet.user.dto.UserResponseDto;
 import com.splanet.splanet.user.service.UserService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/token")
-@Tag(name = "Tokens", description = "토큰 관련 API")
 @RequiredArgsConstructor
-public class TokenController {
+public class TokenController implements TokenApi {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
 
-    @PostMapping("/issue")
-    @Operation(summary = "테스트 유저 토큰 발급", description = "테스트용 유저에게 JWT 토큰을 발급합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "토큰이 성공적으로 발급되었습니다.",
-                    content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<String> issueToken(@RequestParam Long userId) {
+    @Override
+    public ResponseEntity<String> issueToken(Long userId) {
         UserResponseDto user = userService.getUserById(userId);
         String token = jwtTokenProvider.createAccessToken(user.getId());
         return ResponseEntity.ok(token);
     }
 
-    @PostMapping("/refresh")
-    @Operation(summary = "리프레시 토큰을 통해 액세스 토큰 재발급", description = "유효한 리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "액세스 토큰이 성공적으로 재발급되었습니다.",
-                    content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<String> refreshAccessToken(@RequestParam String refreshToken,
-                                                     @RequestParam String deviceId) {
+    @Override
+    public ResponseEntity<String> refreshAccessToken(String refreshToken, String deviceId) {
         String newAccessToken = tokenService.regenerateAccessToken(refreshToken, deviceId);
         return ResponseEntity.ok(newAccessToken);
     }
 
-    @DeleteMapping("/delete")
-    @Operation(summary = "리프레시 토큰 삭제", description = "리프레시 토큰을 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "리프레시 토큰이 성공적으로 삭제되었습니다."),
-            @ApiResponse(responseCode = "400", description = "유효하지 않은 리프레시 토큰입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<Void> deleteRefreshToken(@RequestParam Long userId, @RequestParam String deviceId) {
+    @Override
+    public ResponseEntity<Void> deleteRefreshToken(Long userId, String deviceId) {
         tokenService.deleteRefreshToken(userId, deviceId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/splanet/splanet/jwt/entity/RefreshToken.java
+++ b/src/main/java/com/splanet/splanet/jwt/entity/RefreshToken.java
@@ -14,11 +14,10 @@ import org.springframework.data.redis.core.TimeToLive;
 public class RefreshToken {
 
     @Id
+    private String key;
+
     private String token;
 
-    private Long userId;
-
-
     @TimeToLive
-    Long expiration;
+    private Long expiration;
 }

--- a/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.util.Map;
@@ -24,6 +25,8 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
   private final UserRepository userRepository;
   private final TokenService tokenService;
 
+  @Value("${spring.security.oauth2.redirect-url}")
+  private String redirectUrl;
 
   public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider, UserRepository userRepository, TokenService tokenService) {
     this.jwtTokenProvider = jwtTokenProvider;
@@ -62,13 +65,13 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     tokenService.storeRefreshToken(refreshToken, user.getId(), deviceId);
 
 
-    String redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:5173/oauth2/redirect")
+    String redirectUrlWithParams = UriComponentsBuilder.fromUriString(redirectUrl)
             .queryParam("access", accessToken)
             .queryParam("refresh", refreshToken)
             .queryParam("deviceId", deviceId)
             .build().toUriString();
 
-    response.sendRedirect(redirectUrl);
+    response.sendRedirect(redirectUrlWithParams);
   }
 
   private String generateUniqueNickname(String nickname) {

--- a/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -75,8 +75,10 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
   }
 
   private String generateUniqueNickname(String nickname) {
+    String uniqueSuffix = UUID.randomUUID().toString().split("-")[0];
+
     return userRepository.findByNickname(nickname)
-            .map(existingUser -> nickname + "#" + System.currentTimeMillis() % 10000) // 중복되면 임의값 추가
+            .map(existingUser -> nickname + "#" + uniqueSuffix)
             .orElse(nickname);
   }
 }

--- a/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/splanet/splanet/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 @Component
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
@@ -53,15 +54,18 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
               return userRepository.save(newUser);
             });
 
+    String deviceId = UUID.randomUUID().toString();
+
     String accessToken = jwtTokenProvider.createAccessToken(user.getId());
-    String refreshToken = jwtTokenProvider.createRefreshToken();
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
+    tokenService.storeRefreshToken(refreshToken, user.getId(), deviceId);
 
-    tokenService.storeRefreshToken(refreshToken, user.getId());
 
     String redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:5173/oauth2/redirect")
             .queryParam("access", accessToken)
             .queryParam("refresh", refreshToken)
+            .queryParam("deviceId", deviceId)
             .build().toUriString();
 
     response.sendRedirect(redirectUrl);

--- a/src/main/java/com/splanet/splanet/payment/controller/PaymentApi.java
+++ b/src/main/java/com/splanet/splanet/payment/controller/PaymentApi.java
@@ -1,0 +1,56 @@
+package com.splanet.splanet.payment.controller;
+
+import com.splanet.splanet.core.exception.ErrorResponse;
+import com.splanet.splanet.payment.dto.PaymentRequest;
+import com.splanet.splanet.payment.dto.PaymentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RequestMapping("/api/payment")
+@Tag(name = "Payments", description = "결제 관련 API")
+public interface PaymentApi {
+
+    @PostMapping
+    @Operation(summary = "결제 생성", description = "새로운 구독 결제를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "결제가 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 구독 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 결제 처리에 실패했습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Map<String, Object>> createPayment(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "결제 요청 정보", required = true) @RequestBody PaymentRequest request);
+
+    @DeleteMapping("/{paymentId}")
+    @Operation(summary = "결제 삭제", description = "특정 결제 상태를 삭제 합니다.")
+    ResponseEntity<Map<String, String>> deletePayment(
+            @Parameter(description = "결제 ID", required = true) @PathVariable Long paymentId);
+
+    @GetMapping("/{paymentId}")
+    @Operation(summary = "결제 상태 조회", description = "결제 내역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "결제 정보가 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다 (유효하지 않은 결제 ID).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PaymentResponse> getPaymentStatus(
+            @Parameter(description = "결제 ID", required = true) @PathVariable Long paymentId);
+}

--- a/src/main/java/com/splanet/splanet/payment/controller/PaymentController.java
+++ b/src/main/java/com/splanet/splanet/payment/controller/PaymentController.java
@@ -1,80 +1,39 @@
 package com.splanet.splanet.payment.controller;
 
-import com.splanet.splanet.core.exception.ErrorResponse;
 import com.splanet.splanet.payment.dto.PaymentRequest;
 import com.splanet.splanet.payment.dto.PaymentResponse;
 import com.splanet.splanet.payment.service.PaymentService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/payment")
-@Tag(name = "Payments", description = "결제 관련 API")
-public class PaymentController {
+public class PaymentController implements PaymentApi {
 
     private final PaymentService paymentService;
 
-    @PostMapping
-    @Operation(summary = "결제 생성", description = "새로운 구독 결제를 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "결제가 성공적으로 생성되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 구독 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500",
-                    description = "서버 오류로 결제 처리에 실패했습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<Map<String, Object>> createPayment(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody PaymentRequest request) {
-
+    @Override
+    public ResponseEntity<Map<String, Object>> createPayment(Long userId, PaymentRequest request) {
         PaymentResponse response = paymentService.createPayment(userId, request);
-
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
                 "message", "결제가 성공적으로 생성되었습니다.",
                 "payment", response
         ));
     }
 
-    @DeleteMapping("/{paymentId}")
-    @Operation(summary = "결제 삭제", description = "특정 결제 상태를 삭제 합니다.")
-    public ResponseEntity<Map<String, String>> deletePayment(@PathVariable Long paymentId) {
+    @Override
+    public ResponseEntity<Map<String, String>> deletePayment(Long paymentId) {
         paymentService.deletePayment(paymentId);
         return ResponseEntity.ok().body(Map.of("message", "결제가 성공적으로 삭제되었습니다."));
     }
 
-    @GetMapping("/{paymentId}")
-    @Operation(summary = "결제 상태 조회", description = "결제 내역을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "결제 정보가 성공적으로 조회되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PaymentResponse.class))),
-            @ApiResponse(responseCode = "400",
-                    description = "잘못된 요청입니다 (유효하지 않은 결제 ID).",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<PaymentResponse> getPaymentStatus(@PathVariable Long paymentId) {
+    @Override
+    public ResponseEntity<PaymentResponse> getPaymentStatus(Long paymentId) {
         PaymentResponse response = paymentService.getPaymentStatus(paymentId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/splanet/splanet/plan/controller/PlanApi.java
+++ b/src/main/java/com/splanet/splanet/plan/controller/PlanApi.java
@@ -1,0 +1,73 @@
+package com.splanet.splanet.plan.controller;
+
+import com.splanet.splanet.plan.dto.PlanRequestDto;
+import com.splanet.splanet.plan.dto.PlanResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/plans")
+@Tag(name = "Plans", description = "플랜 관련 API")
+public interface PlanApi {
+
+    @PostMapping
+    @Operation(summary = "플랜 생성", description = "로그인한 사용자가 새로운 플랜을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다. 필수 필드가 누락되었거나 유효하지 않은 값이 포함되어 있습니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 유효한 JWT 토큰이 필요합니다.", content = @Content)
+    })
+    ResponseEntity<PlanResponseDto> createPlan(
+            @Parameter(description = "JWT 인증을 통해 추출된 사용자 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "생성할 플랜의 정보", required = true) @RequestBody PlanRequestDto requestDto);
+
+    @GetMapping("/{planId}")
+    @Operation(summary = "플랜 조회", description = "특정 플랜의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다. 제공된 ID에 해당하는 플랜이 존재하지 않습니다.", content = @Content)
+    })
+    ResponseEntity<PlanResponseDto> getPlan(
+            @Parameter(description = "조회할 플랜의 ID", required = true, example = "1") @PathVariable Long planId);
+
+    @GetMapping
+    @Operation(summary = "전체 플랜 조회", description = "로그인한 사용자의 전체 플랜 리스트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 목록이 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 유효한 JWT 토큰이 필요합니다.", content = @Content)
+    })
+    ResponseEntity<List<PlanResponseDto>> getAllPlans(
+            @Parameter(description = "JWT 인증을 통해 추출된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @PutMapping("/{planId}")
+    @Operation(summary = "플랜 수정", description = "기존 플랜의 내용을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 수정되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다. 제공된 ID에 해당하는 플랜이 존재하지 않습니다.", content = @Content)
+    })
+    ResponseEntity<PlanResponseDto> updatePlan(
+            @Parameter(description = "수정할 플랜의 ID", required = true, example = "1") @PathVariable Long planId,
+            @Parameter(description = "수정할 플랜의 정보", required = true) @RequestBody PlanRequestDto requestDto);
+
+    @DeleteMapping("/{planId}")
+    @Operation(summary = "플랜 삭제", description = "특정 플랜을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다. 제공된 ID에 해당하는 플랜이 존재하지 않습니다.", content = @Content)
+    })
+    ResponseEntity<Void> deletePlan(
+            @Parameter(description = "삭제할 플랜의 ID", required = true, example = "1") @PathVariable Long planId);
+}

--- a/src/main/java/com/splanet/splanet/plan/controller/PlanController.java
+++ b/src/main/java/com/splanet/splanet/plan/controller/PlanController.java
@@ -3,12 +3,6 @@ package com.splanet.splanet.plan.controller;
 import com.splanet.splanet.plan.dto.PlanRequestDto;
 import com.splanet.splanet.plan.dto.PlanResponseDto;
 import com.splanet.splanet.plan.service.PlanService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,76 +11,37 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/plans")
 @RequiredArgsConstructor
-@Tag(name = "Plans", description = "플랜 관리 관련 API")
-public class PlanController {
+public class PlanController implements PlanApi {
 
     private final PlanService planService;
 
-    @PostMapping
-    @Operation(summary = "플랜 생성", description = "새로운 플랜을 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 생성되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content)
-    })
-    public ResponseEntity<PlanResponseDto> createPlan(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody PlanRequestDto requestDto) {
+    @Override
+    public ResponseEntity<PlanResponseDto> createPlan(@AuthenticationPrincipal Long userId, @RequestBody PlanRequestDto requestDto) {
         PlanResponseDto responseDto = planService.createPlan(userId, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/{planId}")
-    @Operation(summary = "플랜 조회", description = "특정 플랜의 상세 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 조회되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다.", content = @Content)
-    })
-    public ResponseEntity<PlanResponseDto> getPlan(
-            @PathVariable Long planId) {
+    @Override
+    public ResponseEntity<PlanResponseDto> getPlan(@PathVariable Long planId) {
         PlanResponseDto responseDto = planService.getPlanById(planId);
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping
-    @Operation(summary = "전체 플랜 조회", description = "유저의 전체 플랜 리스트를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "플랜 목록이 성공적으로 조회되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content)
-    })
-    public ResponseEntity<List<PlanResponseDto>> getAllPlans(
-            @AuthenticationPrincipal Long userId) {
+    @Override
+    public ResponseEntity<List<PlanResponseDto>> getAllPlans(@AuthenticationPrincipal Long userId) {
         List<PlanResponseDto> plans = planService.getAllPlansByUserId(userId);
         return ResponseEntity.ok(plans);
     }
 
-    @PutMapping("/{planId}")
-    @Operation(summary = "플랜 수정", description = "기존 플랜의 내용을 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 수정되었습니다.",
-                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다.", content = @Content)
-    })
-    public ResponseEntity<PlanResponseDto> updatePlan(
-            @PathVariable Long planId,
-            @RequestBody PlanRequestDto requestDto) {
+    @Override
+    public ResponseEntity<PlanResponseDto> updatePlan(@PathVariable Long planId, @RequestBody PlanRequestDto requestDto) {
         PlanResponseDto updatedPlan = planService.updatePlan(planId, requestDto);
         return ResponseEntity.ok(updatedPlan);
     }
 
-    @DeleteMapping("/{planId}")
-    @Operation(summary = "플랜 삭제", description = "특정 플랜을 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "플랜이 성공적으로 삭제되었습니다."),
-            @ApiResponse(responseCode = "404", description = "플랜을 찾을 수 없습니다.", content = @Content)
-    })
-    public ResponseEntity<Void> deletePlan(
-            @PathVariable Long planId) {
+    @Override
+    public ResponseEntity<Void> deletePlan(@PathVariable Long planId) {
         planService.deletePlan(planId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/splanet/splanet/subscription/controller/SubscriptionApi.java
+++ b/src/main/java/com/splanet/splanet/subscription/controller/SubscriptionApi.java
@@ -1,0 +1,55 @@
+package com.splanet.splanet.subscription.controller;
+
+import com.splanet.splanet.subscription.dto.SubscriptionRequest;
+import com.splanet.splanet.subscription.dto.SubscriptionResponse;
+import com.splanet.splanet.core.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/subscription/me")
+@Tag(name = "Subscription", description = "구독 관련 API")
+public interface SubscriptionApi {
+
+    @GetMapping
+    @Operation(summary = "구독 조회", description = "사용자의 구독 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구독 정보가 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = SubscriptionResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "활성화된 구독을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SubscriptionResponse> getSubscription(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @DeleteMapping
+    @Operation(summary = "구독 취소", description = "사용자의 구독을 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구독이 성공적으로 취소되었습니다."),
+            @ApiResponse(responseCode = "400", description = "이미 취소된 구독입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<String> cancelSubscription(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @PostMapping("/payment")
+    @Operation(summary = "구독", description = "사용자가 구독을 구매합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구독이 성공적으로 구매되었습니다.",
+                    content = @Content(schema = @Schema(implementation = SubscriptionResponse.class)))
+    })
+    ResponseEntity<SubscriptionResponse> subscribe(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "구독 결제 요청 정보", required = true) @RequestBody SubscriptionRequest request);
+}

--- a/src/main/java/com/splanet/splanet/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/splanet/splanet/subscription/controller/SubscriptionController.java
@@ -3,65 +3,29 @@ package com.splanet.splanet.subscription.controller;
 import com.splanet.splanet.subscription.dto.SubscriptionRequest;
 import com.splanet.splanet.subscription.dto.SubscriptionResponse;
 import com.splanet.splanet.subscription.service.SubscriptionService;
-import com.splanet.splanet.core.exception.ErrorResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/subscription/me")
-@Tag(name = "subscription", description = "구독 관련 API")
-public class SubscriptionController {
+@RequiredArgsConstructor
+public class SubscriptionController implements SubscriptionApi {
 
     private final SubscriptionService subscriptionService;
 
-    public SubscriptionController(SubscriptionService subscriptionService) {
-        this.subscriptionService = subscriptionService;
-    }
-
-    @GetMapping
-    @Operation(summary = "구독 조회", description = "사용자의 구독 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "구독 정보가 성공적으로 조회되었습니다.",
-                    content = @Content(schema = @Schema(implementation = SubscriptionResponse.class))),
-            @ApiResponse(responseCode = "401",
-                    description = "인증되지 않은 사용자입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404",
-                    description = "활성화된 구독을 찾을 수 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    public ResponseEntity<SubscriptionResponse> getSubscription(@AuthenticationPrincipal Long userId) {
+    @Override
+    public ResponseEntity<SubscriptionResponse> getSubscription(Long userId) {
         return subscriptionService.getSubscription(userId);
     }
 
-    @DeleteMapping
-    @Operation(summary = "구독 취소", description = "사용자의 구독을 취소합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "구독이 성공적으로 취소되었습니다."),
-            @ApiResponse(responseCode = "400", description = "이미 취소된 구독입니다."),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
-    })
-    public ResponseEntity<String> cancelSubscription(@AuthenticationPrincipal Long userId) {
+    @Override
+    public ResponseEntity<String> cancelSubscription(Long userId) {
         return subscriptionService.cancelSubscription(userId);
     }
 
-    @PostMapping("/payment")
-    @Operation(summary = "구독", description = "사용자가 구독을 구매합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "구독이 성공적으로 구매되었습니다.",
-                    content = @Content(schema = @Schema(implementation = SubscriptionResponse.class)))
-    })
-    public ResponseEntity<SubscriptionResponse> subscribe(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody SubscriptionRequest request) {
+    @Override
+    public ResponseEntity<SubscriptionResponse> subscribe(Long userId, SubscriptionRequest request) {
         return subscriptionService.subscribe(userId, request);
     }
 }

--- a/src/main/java/com/splanet/splanet/user/controller/UserApi.java
+++ b/src/main/java/com/splanet/splanet/user/controller/UserApi.java
@@ -1,0 +1,66 @@
+package com.splanet.splanet.user.controller;
+
+import com.splanet.splanet.user.dto.UserResponseDto;
+import com.splanet.splanet.user.dto.UserUpdateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/users")
+@Tag(name = "Users", description = "유저 관련 API")
+public interface UserApi {
+
+    @GetMapping("/me")
+    @Operation(summary = "유저 정보 조회", description = "현재 로그인한 유저의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 반환되었습니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<UserResponseDto> getUserInfo(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @PutMapping("/me")
+    @Operation(summary = "유저 정보 수정", description = "유저의 닉네임, 프로필 이미지, 프리미엄 여부를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 수정되었습니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청. 필드 값이 잘못되었습니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<UserResponseDto> updateUserInfo(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "수정할 유저 정보", required = true) @RequestBody UserUpdateRequestDto requestDto);
+
+    @DeleteMapping("/me")
+    @Operation(summary = "유저 삭제", description = "현재 로그인한 유저의 계정을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저가 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<Void> deleteUser(
+            @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @PostMapping("/create")
+    @Operation(summary = "유저 생성", description = "테스트용 새로운 유저를 생성합니다. 닉네임 중복 시 예외가 발생합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "유저가 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "닉네임이 중복되었습니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
+    })
+    ResponseEntity<UserResponseDto> createUser(
+            @Parameter(description = "새로운 유저의 닉네임", required = true) @RequestParam String nickname,
+            @Parameter(description = "새로운 유저의 프로필 이미지", required = false) @RequestParam(required = false) String profileImage,
+            @Parameter(description = "새로운 유저의 프리미엄 여부", required = false) @RequestParam(required = false) Boolean isPremium);
+}

--- a/src/main/java/com/splanet/splanet/user/controller/UserController.java
+++ b/src/main/java/com/splanet/splanet/user/controller/UserController.java
@@ -3,82 +3,38 @@ package com.splanet.splanet.user.controller;
 import com.splanet.splanet.user.dto.UserResponseDto;
 import com.splanet.splanet.user.dto.UserUpdateRequestDto;
 import com.splanet.splanet.user.service.UserService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/users")
-@Tag(name = "Users", description = "유저 정보 관련 API")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApi {
 
     private final UserService userService;
 
-    @GetMapping("/me")
-    @Operation(summary = "유저 정보 조회", description = "토큰을 사용하여 현재 로그인한 유저의 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 반환되었습니다.",
-                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<UserResponseDto> getUserInfo(
-            @AuthenticationPrincipal Long userId) {
+    @Override
+    public ResponseEntity<UserResponseDto> getUserInfo(Long userId) {
         UserResponseDto userResponse = userService.getUserById(userId);
         return ResponseEntity.ok(userResponse);
     }
 
-    @PutMapping("/me")
-    @Operation(summary = "유저 정보 수정", description = "유저의 닉네임, 프로필 이미지, 프리미엄 여부를 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "유저 정보가 성공적으로 수정되었습니다.",
-                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청. 필드 값이 잘못되었습니다.", content = @Content),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<UserResponseDto> updateUserInfo(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody UserUpdateRequestDto requestDto) {
+    @Override
+    public ResponseEntity<UserResponseDto> updateUserInfo(Long userId, UserUpdateRequestDto requestDto) {
         UserResponseDto updatedUser = userService.updateUserInfo(userId, requestDto);
         return ResponseEntity.ok(updatedUser);
     }
 
-    @DeleteMapping("/me")
-    @Operation(summary = "유저 삭제", description = "현재 로그인한 유저의 계정을 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "유저가 성공적으로 삭제되었습니다."),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<Void> deleteUser(
-            @AuthenticationPrincipal Long userId) {
+    @Override
+    public ResponseEntity<Void> deleteUser(Long userId) {
         userService.deleteUser(userId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/create")
-    @Operation(summary = "유저 생성", description = "테스트용 새로운 유저를 생성합니다. 닉네임 중복 시 예외가 발생합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "유저가 성공적으로 생성되었습니다.",
-                    content = @Content(schema = @Schema(implementation = UserResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "닉네임이 중복되었습니다.", content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류.", content = @Content)
-    })
-    public ResponseEntity<UserResponseDto> createUser(
-            @RequestParam String nickname,
-            @RequestParam(required = false) String profileImage,
-            @RequestParam(required = false) Boolean isPremium) {
+    @Override
+    public ResponseEntity<UserResponseDto> createUser(String nickname, String profileImage, Boolean isPremium) {
         UserResponseDto newUser = userService.createUser(nickname, profileImage, isPremium);
         return ResponseEntity.status(201).body(newUser);
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
     import: env.properties
   security:
     oauth2:
+      redirect-url: ${REDIRECT_URL}
       client:
         provider:
           kakao:
@@ -38,10 +39,11 @@ spring:
             scope: profile_nickname, profile_image, account_email
             client-name: Kakao
 
-
 logging:
   level:
     org.springframework.security: TRACE
+
 springdoc:
   swagger-ui:
     path: /swagger
+


### PR DESCRIPTION
## 📄요약

> #46  에서 받은 피드백을 바탕으로 코드를 수정한다. 

## 🖋️작업 내용

- [x]  Redis 키를 userId로 변경
- [x]  로그인 할 때 deviceId를 추가로 발급하고, 해당 Id를 통해 다중 로그인 관리
- [x]  OAuth2AuthenticationSuccessHandler 의 하드코딩 및 비약점 수정
- [x]  컨트롤러의 스웨거 설명을 인터페이스 나누기

## 📷스크린샷
![image](https://github.com/user-attachments/assets/82ee5ad0-6f4a-4bd7-8e91-6f7069e61a52)
redis에 userId와 deviceId가 키로 설정된 모습

## ❗참고 사항
- env.properties에 변동사항이 있으니 슬랙에서 확인해주세요

- https://kanguk-room.notion.site/5-117036cad7a880589527e6a551658bf0?pvs=4
에 간단히 설명을 작성하면서 진행했으니 필요한분은 참고해주세요

- https://kanguk-room.notion.site/Refresh-Token-With-Redis-114036cad7a8805687bfe7e3b5ce5e75?pvs=4
여기에는 `Refresh Token` 관련 내용을 작성했으니 이부분도 참고하면 좋을 듯 하네요
## 🔗이슈
close #48 
