### PR TITLE
[feature]: PreviewPlan 구현

### DIFF
--- a/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
+++ b/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
@@ -34,7 +34,10 @@ public enum ErrorCode {
     TEAM_MEMBER_NOT_FOUND("해당 유저는 팀에 속해 있지 않습니다.", HttpStatus.NOT_FOUND),
     INVITATION_NOT_FOUND("초대를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVITATION_ALREADY_PROCESSED("초대가 이미 처리되었습니다.", HttpStatus.BAD_REQUEST),
-    USER_ALREADY_IN_TEAM("해당 유저는 이미 팀에 속해 있습니다.", HttpStatus.BAD_REQUEST);
+    USER_ALREADY_IN_TEAM("해당 유저는 이미 팀에 속해 있습니다.", HttpStatus.BAD_REQUEST),
+
+    // redis
+    REDIS_SCAN_FAILED("Redis 키 스캔 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/splanet/splanet/plan/controller/PlanApi.java
+++ b/src/main/java/com/splanet/splanet/plan/controller/PlanApi.java
@@ -70,4 +70,17 @@ public interface PlanApi {
     })
     ResponseEntity<Void> deletePlan(
             @Parameter(description = "삭제할 플랜의 ID", required = true, example = "1") @PathVariable Long planId);
+
+    @PostMapping("/save-preview/{deviceId}/{groupId}")
+    @Operation(summary = "프리뷰 플랜 저장", description = "해당 디바이스 ID와 그룹 ID의 모든 플랜 카드를 사용자의 플랜으로 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프리뷰 플랜이 성공적으로 저장되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 프리뷰 플랜을 찾을 수 없습니다.", content = @Content)
+    })
+    ResponseEntity<List<PlanResponseDto>> savePreviewToPlans(
+            @Parameter(description = "JWT 인증을 통해 추출된 사용자 ID", required = true) @AuthenticationPrincipal Long userId,
+            @Parameter(description = "디바이스 ID", required = true) @PathVariable String deviceId,
+            @Parameter(description = "그룹 ID", required = true) @PathVariable String groupId);
+
 }

--- a/src/main/java/com/splanet/splanet/plan/controller/PlanController.java
+++ b/src/main/java/com/splanet/splanet/plan/controller/PlanController.java
@@ -45,4 +45,10 @@ public class PlanController implements PlanApi {
         planService.deletePlan(planId);
         return ResponseEntity.ok().build();
     }
+
+    @Override
+    public ResponseEntity<List<PlanResponseDto>> savePreviewToPlans(Long userId, String deviceId, String groupId) {
+        List<PlanResponseDto> savedPlans = planService.saveGroupCardsToUser(userId, deviceId, groupId);
+        return ResponseEntity.ok(savedPlans);
+    }
 }

--- a/src/main/java/com/splanet/splanet/plan/dto/PlanRequestDto.java
+++ b/src/main/java/com/splanet/splanet/plan/dto/PlanRequestDto.java
@@ -12,6 +12,9 @@ public class PlanRequestDto {
     private String description;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private Boolean accessibility;
-    private Boolean isCompleted;
+
+    @Builder.Default
+    private Boolean accessibility = true;
+    @Builder.Default
+    private Boolean isCompleted = false;
 }

--- a/src/main/java/com/splanet/splanet/plan/entity/Plan.java
+++ b/src/main/java/com/splanet/splanet/plan/entity/Plan.java
@@ -39,6 +39,7 @@ public class Plan extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime endDate;
 
+    @Builder.Default
     @Column(nullable = true)
     private Boolean accessibility = true;
 

--- a/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanApi.java
+++ b/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanApi.java
@@ -1,0 +1,80 @@
+package com.splanet.splanet.previewplan.controller;
+
+import com.splanet.splanet.previewplan.dto.PlanCardRequestDto;
+import com.splanet.splanet.previewplan.dto.PlanCardResponseDto;
+import com.splanet.splanet.previewplan.dto.PlanGroupWithCardsResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@Tag(name = "Preview Plans", description = "Preview Plan 및 Plan Card 관련 API")
+@RequestMapping("/api/preview-plan")
+public interface PreviewPlanApi {
+
+    @PostMapping("/card")
+    @Operation(summary = "플랜 카드 생성", description = "새로운 플랜 카드를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 카드가 성공적으로 생성되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanCardResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content)
+    })
+    ResponseEntity<PlanCardResponseDto> createPlanCard(
+            @Parameter(description = "디바이스 ID", required = true) @RequestParam String deviceId,
+            @Parameter(description = "그룹 ID", required = true) @RequestParam String groupId,
+            @Parameter(description = "생성할 플랜 카드 정보", required = true) @RequestBody PlanCardRequestDto planCardRequestDto);
+
+    @GetMapping("/card/{deviceId}/{groupId}/{cardId}")
+    @Operation(summary = "플랜 카드 조회", description = "특정 플랜 카드를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 카드가 성공적으로 조회되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanCardResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 카드를 찾을 수 없습니다.", content = @Content)
+    })
+    ResponseEntity<PlanCardResponseDto> getPlanCard(
+            @Parameter(description = "디바이스 ID", required = true) @PathVariable String deviceId,
+            @Parameter(description = "그룹 ID", required = true) @PathVariable String groupId,
+            @Parameter(description = "카드 ID", required = true) @PathVariable String cardId);
+
+    @PutMapping("/card/{deviceId}/{groupId}/{cardId}")
+    @Operation(summary = "플랜 카드 수정", description = "기존 플랜 카드를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 카드가 성공적으로 수정되었습니다.",
+                    content = @Content(schema = @Schema(implementation = PlanCardResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "플랜 카드를 찾을 수 없습니다.", content = @Content)
+    })
+    ResponseEntity<PlanCardResponseDto> updatePlanCard(
+            @Parameter(description = "디바이스 ID", required = true) @PathVariable String deviceId,
+            @Parameter(description = "그룹 ID", required = true) @PathVariable String groupId,
+            @Parameter(description = "카드 ID", required = true) @PathVariable String cardId,
+            @Parameter(description = "수정할 플랜 카드 정보", required = true) @RequestBody PlanCardRequestDto planCardRequestDto);
+
+    @DeleteMapping("/card/{deviceId}/{groupId}/{cardId}")
+    @Operation(summary = "플랜 카드 삭제", description = "특정 플랜 카드를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 카드가 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "404", description = "플랜 카드를 찾을 수 없습니다.", content = @Content)
+    })
+    ResponseEntity<Void> deletePlanCard(
+            @Parameter(description = "디바이스 ID", required = true) @PathVariable String deviceId,
+            @Parameter(description = "그룹 ID", required = true) @PathVariable String groupId,
+            @Parameter(description = "카드 ID", required = true) @PathVariable String cardId);
+
+    @GetMapping("/")
+    @Operation(summary = "디바이스 ID를 통해 각 그룹에 맞는 모든 플랜 카드 조회", description = "디바이스 ID에 맞는 모든 PlanGroup과 해당 PlanCard를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 PlanGroup 및 PlanCard 조회 완료",
+                    content = @Content(schema = @Schema(implementation = PlanGroupWithCardsResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 PlanGroup이나 PlanCard가 존재하지 않음", content = @Content)
+    })
+    ResponseEntity<Set<PlanGroupWithCardsResponseDto>> getPreviewPlans(
+            @Parameter(description = "조회할 디바이스 ID", required = true) @RequestParam String deviceId);
+}

--- a/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanController.java
+++ b/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanController.java
@@ -1,0 +1,48 @@
+package com.splanet.splanet.previewplan.controller;
+
+import com.splanet.splanet.previewplan.dto.PlanCardRequestDto;
+import com.splanet.splanet.previewplan.dto.PlanCardResponseDto;
+import com.splanet.splanet.previewplan.dto.PlanGroupWithCardsResponseDto;
+import com.splanet.splanet.previewplan.service.PreviewPlanService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Set;
+
+@RestController
+@RequiredArgsConstructor
+public class PreviewPlanController implements PreviewPlanApi {
+
+    private final PreviewPlanService previewPlanService;
+
+    @Override
+    public ResponseEntity<PlanCardResponseDto> createPlanCard(String deviceId, String groupId, PlanCardRequestDto planCardRequestDto) {
+        PlanCardResponseDto responseDto = previewPlanService.savePlanCard(deviceId, groupId, planCardRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Override
+    public ResponseEntity<PlanCardResponseDto> getPlanCard(String deviceId, String groupId, String cardId) {
+        PlanCardResponseDto responseDto = previewPlanService.getPlanCard(deviceId, groupId, cardId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Override
+    public ResponseEntity<PlanCardResponseDto> updatePlanCard(String deviceId, String groupId, String cardId, PlanCardRequestDto planCardRequestDto) {
+        PlanCardResponseDto responseDto = previewPlanService.updatePlanCard(deviceId, groupId, cardId, planCardRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @Override
+    public ResponseEntity<Void> deletePlanCard(String deviceId, String groupId, String cardId) {
+        previewPlanService.deletePlanCard(deviceId, groupId, cardId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Set<PlanGroupWithCardsResponseDto>> getPreviewPlans(String deviceId) {
+        Set<PlanGroupWithCardsResponseDto> previewPlans = previewPlanService.getPreviewPlans(deviceId);
+        return ResponseEntity.ok(previewPlans);
+    }
+}

--- a/src/main/java/com/splanet/splanet/previewplan/dto/PlanCardRequestDto.java
+++ b/src/main/java/com/splanet/splanet/previewplan/dto/PlanCardRequestDto.java
@@ -1,0 +1,9 @@
+package com.splanet.splanet.previewplan.dto;
+
+public record PlanCardRequestDto(
+        String title,
+        String description,
+        String startDate,
+        String endDate
+) {
+}

--- a/src/main/java/com/splanet/splanet/previewplan/dto/PlanCardResponseDto.java
+++ b/src/main/java/com/splanet/splanet/previewplan/dto/PlanCardResponseDto.java
@@ -1,0 +1,25 @@
+package com.splanet.splanet.previewplan.dto;
+
+import com.splanet.splanet.previewplan.entity.PlanCard;
+
+public record PlanCardResponseDto(
+        String deviceId,
+        String groupId,
+        String cardId,
+        String title,
+        String description,
+        String startDate,
+        String endDate
+) {
+    public static PlanCardResponseDto from(PlanCard planCard) {
+        return new PlanCardResponseDto(
+                planCard.getDeviceId(),
+                planCard.getGroupId(),
+                planCard.getCardId(),
+                planCard.getTitle(),
+                planCard.getDescription(),
+                planCard.getStartDate(),
+                planCard.getEndDate()
+        );
+    }
+}

--- a/src/main/java/com/splanet/splanet/previewplan/dto/PlanGroupWithCardsResponseDto.java
+++ b/src/main/java/com/splanet/splanet/previewplan/dto/PlanGroupWithCardsResponseDto.java
@@ -1,0 +1,10 @@
+package com.splanet.splanet.previewplan.dto;
+
+import java.util.Set;
+
+public record PlanGroupWithCardsResponseDto(
+        String deviceId,
+        String groupId,
+        Set<PlanCardResponseDto> planCards
+) {
+}

--- a/src/main/java/com/splanet/splanet/previewplan/entity/PlanCard.java
+++ b/src/main/java/com/splanet/splanet/previewplan/entity/PlanCard.java
@@ -1,0 +1,39 @@
+package com.splanet.splanet.previewplan.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@RedisHash("planCard")
+public class PlanCard {
+
+    @Id
+    private String customKey;
+
+    private String deviceId;
+    private String groupId;
+    private String cardId;
+    private String title;
+    private String description;
+    private String startDate;
+    private String endDate;
+
+    @TimeToLive(unit = TimeUnit.HOURS)
+    private Long expiration = 1L;
+
+    public static String generateId() {
+        return UUID.randomUUID().toString().split("-")[0];
+    }
+}
+

--- a/src/main/java/com/splanet/splanet/previewplan/entity/PlanGroup.java
+++ b/src/main/java/com/splanet/splanet/previewplan/entity/PlanGroup.java
@@ -1,0 +1,30 @@
+package com.splanet.splanet.previewplan.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@RedisHash("planGroup")
+public class PlanGroup {
+
+    @Id
+    private String customKey;
+
+    private String deviceId;
+    private String groupId;
+    private Set<String> planCardIds;
+
+    @TimeToLive(unit = TimeUnit.HOURS)
+    private Long expiration = 1L;
+}

--- a/src/main/java/com/splanet/splanet/previewplan/entity/PreviewPlan.java
+++ b/src/main/java/com/splanet/splanet/previewplan/entity/PreviewPlan.java
@@ -1,0 +1,26 @@
+package com.splanet.splanet.previewplan.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash("previewPlan")
+public class PreviewPlan {
+
+    @Id
+    private String deviceId;
+
+    private List<String> groupIds;
+
+    @TimeToLive(unit = TimeUnit.HOURS)
+    private Long expiration = 1L;
+}

--- a/src/main/java/com/splanet/splanet/previewplan/repository/PlanCardRepository.java
+++ b/src/main/java/com/splanet/splanet/previewplan/repository/PlanCardRepository.java
@@ -1,0 +1,8 @@
+package com.splanet.splanet.previewplan.repository;
+
+import com.splanet.splanet.previewplan.entity.PlanCard;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PlanCardRepository extends CrudRepository<PlanCard, String> {
+
+}

--- a/src/main/java/com/splanet/splanet/previewplan/repository/PlanGroupRepository.java
+++ b/src/main/java/com/splanet/splanet/previewplan/repository/PlanGroupRepository.java
@@ -1,0 +1,12 @@
+package com.splanet.splanet.previewplan.repository;
+
+import com.splanet.splanet.previewplan.entity.PlanGroup;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface PlanGroupRepository extends CrudRepository<PlanGroup, String> {
+    void addGroupToDeviceIndex(String indexKey, String groupKey);
+    List<PlanGroup> findAllByDeviceId(String deviceId);
+
+}

--- a/src/main/java/com/splanet/splanet/previewplan/repository/PreviewPlanRepository.java
+++ b/src/main/java/com/splanet/splanet/previewplan/repository/PreviewPlanRepository.java
@@ -1,0 +1,8 @@
+package com.splanet.splanet.previewplan.repository;
+
+import com.splanet.splanet.previewplan.entity.PreviewPlan;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PreviewPlanRepository extends CrudRepository<PreviewPlan, String> {
+
+}

--- a/src/main/java/com/splanet/splanet/previewplan/service/PreviewPlanService.java
+++ b/src/main/java/com/splanet/splanet/previewplan/service/PreviewPlanService.java
@@ -1,0 +1,158 @@
+package com.splanet.splanet.previewplan.service;
+
+import com.splanet.splanet.core.exception.BusinessException;
+import com.splanet.splanet.core.exception.ErrorCode;
+import com.splanet.splanet.previewplan.dto.PlanCardRequestDto;
+import com.splanet.splanet.previewplan.dto.PlanCardResponseDto;
+import com.splanet.splanet.previewplan.dto.PlanGroupWithCardsResponseDto;
+import com.splanet.splanet.previewplan.entity.PlanCard;
+import com.splanet.splanet.previewplan.entity.PlanGroup;
+import com.splanet.splanet.previewplan.repository.PlanCardRepository;
+import com.splanet.splanet.previewplan.repository.PlanGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PreviewPlanService {
+
+    private static final String PLAN_GROUP_PREFIX = "planGroup:";
+    private static final String PLAN_CARD_PREFIX = "planCard:";
+    private static final int PLAN_CARD_PREFIX_LENGTH = PLAN_CARD_PREFIX.length();
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final PlanCardRepository planCardRepository;
+    private final PlanGroupRepository planGroupRepository;
+
+    public PlanCardResponseDto savePlanCard(String deviceId, String groupId, PlanCardRequestDto planCardRequestDto) {
+        String cardId = PlanCard.generateId();
+        String customKey = generateCustomKey(deviceId, groupId, cardId);
+
+        PlanCard newPlanCard = buildPlanCard(customKey, deviceId, groupId, cardId, planCardRequestDto);
+        planCardRepository.save(newPlanCard);
+        updatePlanGroup(deviceId, groupId, cardId, true);
+        return PlanCardResponseDto.from(newPlanCard);
+    }
+
+    public PlanCardResponseDto getPlanCard(String deviceId, String groupId, String cardId) {
+        String redisKey = generateCustomKey(deviceId, groupId, cardId);
+        return planCardRepository.findById(redisKey)
+                .map(PlanCardResponseDto::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    public PlanCardResponseDto updatePlanCard(String deviceId, String groupId, String cardId, PlanCardRequestDto planCardRequestDto) {
+        String redisKey = generateCustomKey(deviceId, groupId, cardId);
+        PlanCard existingPlanCard = planCardRepository.findById(redisKey)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+
+        PlanCard updatedCard = buildPlanCard(redisKey, deviceId, groupId, cardId, planCardRequestDto);
+        planCardRepository.save(updatedCard);
+        return PlanCardResponseDto.from(updatedCard);
+    }
+
+    public void deletePlanCard(String deviceId, String groupId, String cardId) {
+        String redisKey = generateCustomKey(deviceId, groupId, cardId);
+        PlanCard existingPlanCard = planCardRepository.findById(redisKey)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+
+        planCardRepository.delete(existingPlanCard);
+        updatePlanGroup(deviceId, groupId, cardId, false);
+    }
+
+    public Set<PlanGroupWithCardsResponseDto> getPreviewPlans(String deviceId) {
+        Set<String> groupKeys = scanKeysByPattern(PLAN_GROUP_PREFIX + deviceId + ":*");
+
+        return groupKeys.stream()
+                .map(groupKey -> {
+                    String groupId = extractGroupIdFromKey(groupKey);
+
+                    Set<PlanCardResponseDto> planCards = scanKeysByPattern(PLAN_CARD_PREFIX + deviceId + ":" + groupId + ":*").stream()
+                            .map(this::getPlanCardByKey)
+                            .collect(Collectors.toSet());
+
+                    return new PlanGroupWithCardsResponseDto(deviceId, groupId, planCards);
+                })
+                .collect(Collectors.toSet());
+    }
+
+    private PlanCard buildPlanCard(String customKey, String deviceId, String groupId, String cardId, PlanCardRequestDto planCardRequestDto) {
+        return PlanCard.builder()
+                .customKey(customKey)
+                .deviceId(deviceId)
+                .groupId(groupId)
+                .cardId(cardId)
+                .title(planCardRequestDto.title())
+                .description(planCardRequestDto.description())
+                .startDate(planCardRequestDto.startDate())
+                .endDate(planCardRequestDto.endDate())
+                .build();
+    }
+
+    private void updatePlanGroup(String deviceId, String groupId, String cardId, boolean add) {
+        String groupKey = generateGroupKey(deviceId, groupId);
+        PlanGroup planGroup = planGroupRepository.findById(groupKey)
+                .orElse(PlanGroup.builder()
+                        .deviceId(deviceId)
+                        .groupId(groupId)
+                        .planCardIds(new HashSet<>())
+                        .build());
+
+        if (add) {
+            planGroup.getPlanCardIds().add(cardId);
+        } else {
+            planGroup.getPlanCardIds().remove(cardId);
+        }
+        planGroupRepository.save(planGroup);
+    }
+
+    private Set<String> scanKeysByPattern(String pattern) {
+        Set<String> keys = new HashSet<>();
+        ScanOptions scanOptions = ScanOptions.scanOptions().match(pattern).count(100).build();
+
+        try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory().getConnection().scan(scanOptions)) {
+            while (cursor.hasNext()) {
+                keys.add(new String(cursor.next(), StandardCharsets.UTF_8));
+            }
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REDIS_SCAN_FAILED, "패턴으로 SCAN을 할 수 없습니다: " + pattern);
+        }
+
+        return keys;
+    }
+
+    public Set<PlanCardResponseDto> getPlanCardsByGroup(String deviceId, String groupId) {
+        Set<String> cardKeys = scanKeysByPattern(PLAN_CARD_PREFIX + deviceId + ":" + groupId + ":*");
+
+        return cardKeys.stream()
+                .map(this::getPlanCardByKey)
+                .collect(Collectors.toSet());
+    }
+
+    private PlanCardResponseDto getPlanCardByKey(String redisKey) {
+        String key = redisKey.substring(PLAN_CARD_PREFIX_LENGTH);
+        return planCardRepository.findById(key)
+                .map(PlanCardResponseDto::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+    }
+
+    private String generateCustomKey(String deviceId, String groupId, String cardId) {
+        return deviceId + ":" + groupId + ":" + cardId;
+    }
+
+    private String generateGroupKey(String deviceId, String groupId) {
+        return deviceId + ":" + groupId;
+    }
+
+    private String extractGroupIdFromKey(String groupKey) {
+        return groupKey.split(":")[2];
+    }
+}

--- a/src/test/java/com/splanet/splanet/previewplan/service/PreviewPlanServiceTest.java
+++ b/src/test/java/com/splanet/splanet/previewplan/service/PreviewPlanServiceTest.java
@@ -1,0 +1,159 @@
+package com.splanet.splanet.previewplan.service;
+
+import com.splanet.splanet.core.exception.BusinessException;
+import com.splanet.splanet.core.exception.ErrorCode;
+import com.splanet.splanet.previewplan.dto.PlanCardRequestDto;
+import com.splanet.splanet.previewplan.dto.PlanCardResponseDto;
+import com.splanet.splanet.previewplan.entity.PlanCard;
+import com.splanet.splanet.previewplan.entity.PlanGroup;
+import com.splanet.splanet.previewplan.repository.PlanCardRepository;
+import com.splanet.splanet.previewplan.repository.PlanGroupRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class PreviewPlanServiceTest {
+
+    @Mock
+    private PlanCardRepository planCardRepository;
+
+    @Mock
+    private PlanGroupRepository planGroupRepository;
+
+    @InjectMocks
+    private PreviewPlanService previewPlanService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void 플랜카드_성공적으로_저장됨() {
+        // given
+        PlanCardRequestDto requestDto = new PlanCardRequestDto("title", "description", "2024-10-10T10:00:00", "2024-10-10T12:00:00");
+        PlanCard newPlanCard = PlanCard.builder()
+                .customKey("deviceId:groupId:cardId")
+                .deviceId("deviceId")
+                .groupId("groupId")
+                .cardId("cardId")
+                .title(requestDto.title())
+                .description(requestDto.description())
+                .startDate(requestDto.startDate())
+                .endDate(requestDto.endDate())
+                .build();
+
+        when(planCardRepository.save(any(PlanCard.class))).thenReturn(newPlanCard);
+
+        // when
+        PlanCardResponseDto result = previewPlanService.savePlanCard("deviceId", "groupId", requestDto);
+
+        // then
+        assertEquals("title", result.title());
+        assertEquals("description", result.description());
+        assertEquals("2024-10-10T10:00:00", result.startDate());
+        verify(planCardRepository, times(1)).save(any(PlanCard.class));
+    }
+
+    @Test
+    void 플랜카드_찾을_수_없음_예외발생() {
+        // given
+        when(planCardRepository.findById(anyString())).thenReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            previewPlanService.getPlanCard("deviceId", "groupId", "cardId");
+        });
+
+        assertEquals(ErrorCode.PLAN_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 플랜카드_성공적으로_수정됨() {
+        // given
+        PlanCard existingPlanCard = PlanCard.builder()
+                .customKey("deviceId:groupId:cardId")
+                .deviceId("deviceId")
+                .groupId("groupId")
+                .cardId("cardId")
+                .title("oldTitle")
+                .description("oldDescription")
+                .startDate("2024-10-10T10:00:00")
+                .endDate("2024-10-10T12:00:00")
+                .build();
+
+        when(planCardRepository.findById(anyString())).thenReturn(Optional.of(existingPlanCard));
+
+        PlanCardRequestDto updateDto = new PlanCardRequestDto("newTitle", "newDescription", "2024-11-10T10:00:00", "2024-11-10T12:00:00");
+
+        // when
+        PlanCardResponseDto updatedCard = previewPlanService.updatePlanCard("deviceId", "groupId", "cardId", updateDto);
+
+        // then
+        assertEquals("newTitle", updatedCard.title());
+        assertEquals("newDescription", updatedCard.description());
+        verify(planCardRepository, times(1)).save(any(PlanCard.class));
+    }
+
+    @Test
+    void 플랜카드_삭제_성공() {
+        // given
+        PlanCard existingPlanCard = PlanCard.builder()
+                .customKey("deviceId:groupId:cardId")
+                .deviceId("deviceId")
+                .groupId("groupId")
+                .cardId("cardId")
+                .build();
+
+        when(planCardRepository.findById(anyString())).thenReturn(Optional.of(existingPlanCard));
+
+        // when
+        previewPlanService.deletePlanCard("deviceId", "groupId", "cardId");
+
+        // then
+        verify(planCardRepository, times(1)).delete(existingPlanCard);
+    }
+
+    @Test
+    void 플랜그룹_성공적으로_저장됨() {
+        // given
+        Set<String> planCardIds = new HashSet<>();
+        PlanGroup planGroup = PlanGroup.builder()
+                .deviceId("deviceId")
+                .groupId("groupId")
+                .planCardIds(planCardIds)
+                .build();
+
+        when(planGroupRepository.findById(anyString())).thenReturn(Optional.of(planGroup));
+
+        // when
+        previewPlanService.savePlanCard("deviceId", "groupId", new PlanCardRequestDto("title", "description", "2024-10-10T10:00:00", "2024-10-10T12:00:00"));
+
+        // then
+        verify(planGroupRepository, times(1)).save(any(PlanGroup.class));
+    }
+
+    @Test
+    void 예외처리_잘못된_카드키() {
+        // given
+        when(planCardRepository.findById(anyString())).thenReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            previewPlanService.getPlanCard("deviceId", "groupId", "wrongCardId");
+        });
+
+        assertEquals(ErrorCode.PLAN_NOT_FOUND, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 📄요약

> 프리뷰 플랜을 구현한다.

## 🖋️작업 내용

- [ ] redis를 활용하여 previewPlan 로직 구현
- [ ] 특정 그룹을 해당 유저의 plan 테이블에 저장하는 API 구현

## 📷스크린샷
![image](https://github.com/user-attachments/assets/e6a5b1bc-d84a-4e53-987b-4d197b96c893)



## ❗참고 사항
`planCard` : 일정 하나
`planGroup` : 하나의 묶음 (만약 ai가 한 세트의 일정을 주면 그게 그룹입니다.)
`previewPlan` : 그 묶음 3개


## 🔗이슈
close #55 
