### PR TITLE
[refactor]: 친구요청 삭제 메소드 구현

### DIFF
--- a/src/main/java/com/splanet/splanet/friendRequest/controller/FriendRequestApi.java
+++ b/src/main/java/com/splanet/splanet/friendRequest/controller/FriendRequestApi.java
@@ -69,4 +69,17 @@ public interface FriendRequestApi {
     })
     ResponseEntity<List<SentFriendRequestResponse>> getSentRequests(
             @Parameter(description = "JWT 인증으로 전달된 사용자 ID", required = true) @AuthenticationPrincipal Long userId);
+
+    @DeleteMapping("/{requestId}/cancel")
+    @Operation(summary = "친구 요청 취소", description = "특정 친구 요청을 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "친구 요청이 성공적으로 취소되었습니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다."),
+            @ApiResponse(responseCode = "404", description = "해당 친구 요청을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "403", description = "친구요청 권한이 없습니다. 내가 보낸 요청이 아닙니다.")
+    })
+    ResponseEntity<SuccessResponse> cancelFriendRequest(
+            @Parameter(description = "친구 요청 ID", required = true) @PathVariable Long requestId,
+            @AuthenticationPrincipal Long userId);
+
 }

--- a/src/main/java/com/splanet/splanet/friendRequest/controller/FriendRequestController.java
+++ b/src/main/java/com/splanet/splanet/friendRequest/controller/FriendRequestController.java
@@ -58,4 +58,13 @@ public class FriendRequestController implements FriendRequestApi{
     public ResponseEntity<List<SentFriendRequestResponse>> getSentRequests(@AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok(friendRequestService.getSentFriendRequests(userId));
     }
+
+    // 친구 요청 취소
+    @Override
+    public ResponseEntity<SuccessResponse> cancelFriendRequest(@PathVariable Long requestId,
+                                                               @AuthenticationPrincipal Long userId) {
+        friendRequestService.cancelFriendRequest(requestId, userId);
+        SuccessResponse response = new SuccessResponse("친구 요청이 성공적으로 취소되었습니다.");
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/splanet/splanet/friendRequest/service/FriendRequestService.java
+++ b/src/main/java/com/splanet/splanet/friendRequest/service/FriendRequestService.java
@@ -210,4 +210,15 @@ public class FriendRequestService {
                 ))
                 .collect(Collectors.toList());
     }
+
+    // 친구요청 취소하기
+    public void cancelFriendRequest(Long requestId, Long userId) {
+        FriendRequest friendRequest = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        if (!friendRequest.getRequester().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+        friendRequestRepository.delete(friendRequest);
+    }
 }

--- a/src/test/java/com/splanet/splanet/friendRequest/service/FriendRequestServiceTest.java
+++ b/src/test/java/com/splanet/splanet/friendRequest/service/FriendRequestServiceTest.java
@@ -231,4 +231,30 @@ class FriendRequestServiceTest {
 
         assertEquals(ErrorCode.FRIEND_REQUEST_ALREADY_ACCEPTED_OR_REJECTED, exception.getErrorCode());
     }
+
+    @Test
+    void 친구요청취소_성공() {
+        Long requestId = friendRequest.getId();
+        Long userId = requester.getId();
+
+        when(friendRequestRepository.findById(requestId)).thenReturn(Optional.of(friendRequest));
+
+        friendRequestService.cancelFriendRequest(requestId, userId);
+
+        verify(friendRequestRepository, times(1)).delete(friendRequest);
+    }
+
+    @Test
+    void 친구요청취소_권한없음() {
+        Long requestId = friendRequest.getId();
+        Long userId = 999L; // 요청자가 아닌 다른 사용자의 ID
+
+        when(friendRequestRepository.findById(requestId)).thenReturn(Optional.of(friendRequest));
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                friendRequestService.cancelFriendRequest(requestId, userId)
+        );
+
+        assertEquals(ErrorCode.ACCESS_DENIED, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
## 📄요약

> 프론트 연결 중 친구요청 api에서 친구요청 취소 기능이 없음을 발견해서 delete 메소드 만들었습니다.

## 🖋️작업 내용

- [x] 친구요청 api Delete

## 📷스크린샷
![스크린샷 2024-11-01 094119](https://github.com/user-attachments/assets/e0fb4d74-eb4b-4963-82cb-54bccc474afe)
![스크린샷 2024-11-01 094133](https://github.com/user-attachments/assets/3dd49591-0bec-413a-ba4c-9b3caa191572)
![스크린샷 2024-11-01 094147](https://github.com/user-attachments/assets/bddc3f94-d17c-42e5-8241-119d76a798a4)

## ❗참고 사항


## 🔗이슈
close #87
