### PR TITLE
[feat]: GPT 로직 보완

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,395 @@
-# Team3_BE
-3조 백엔드
+# Splanet
+![image](https://github.com/user-attachments/assets/c7f7b8ee-0764-404c-b547-e67dc5c23b77)
+
+### Speak and Plan It! 내 목소리로 만들어지는 나만의 플래너
+
+---
+
+# 목차
+
+- [Splanet](#splanet)
+  - [1. 프로젝트 개요](#1-프로젝트-개요)
+    - [API 명세서](#api-명세서)
+    - [ERD](#erd)
+  - [2. 기술 스택](#2-기술-스택)
+    - [프론트엔드](#프론트엔드)
+    - [백엔드](#백엔드)
+    - [데이터베이스](#데이터베이스)
+    - [인프라](#인프라)
+  - [3. 주요 기능](#3-주요-기능)
+    - [카카오 로그인](#카카오-로그인)
+    - [실시간 음성 인식](#실시간-음성-인식)
+    - [플랜 자동 생성](#플랜-자동-생성)
+    - [플랜 관리](#플랜-관리)
+    - [친구](#친구)
+  - [4. 프로젝트 구조](#4-프로젝트-구조)
+  - [7. 개발 관련](#7-개발-관련)
+
+
+## 1. 프로젝트 개요
+
+계획 짜는 것 마저 계획인 당신에게 선사합니다. 
+
+### API 명세서
+
+### ERD
+![image](https://github.com/user-attachments/assets/40ca0599-f873-4b6d-b970-bd3858e7e86d)
+
+
+---
+
+## 2. 기술 스택
+
+### 프론트엔드
+
+![React](https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=react&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+
+### 백엔드
+
+![Java](https://img.shields.io/badge/Java-007396?style=for-the-badge&logo=java&logoColor=white)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white)
+
+### 데이터베이스
+
+![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=mysql&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-DC382D?style=for-the-badge&logo=redis&logoColor=white)
+
+### 인프라
+
+![Amazon EC2](https://img.shields.io/badge/Amazon%20EC2-FF9900?style=for-the-badge&logo=amazonec2&logoColor=white)
+![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=for-the-badge&logo=githubactions&logoColor=white)
+
+
+---
+
+## 3. 주요 기능
+
+### 카카오 로그인
+
+| ![카카오 로그인](https://github.com/user-attachments/assets/3883651a-f1a0-43f9-8272-70645035adc6) | 카카오 ID를 통해 사용자를 인증합니다. |
+|:---:|---|
+
+### 실시간 음성 인식
+
+| ![실시간 음성 인식](https://github.com/user-attachments/assets/66d14a1b-0396-4ca5-b16e-8574427e4319) | 실시간 음성 인식을 통해 사용자의 요구사항을 작성합니다. |
+|:---:|---|
+
+### 플랜 자동 생성
+
+| ![플랜 자동 생성](https://github.com/user-attachments/assets/66d14a1b-0396-4ca5-b16e-8574427e4319) | 사용자의 요구사항에 맞게 플랜을 자동으로 생성합니다. (fine-tuning 모델 이용) 추천된 3개 중 하나를 선택할 수 있습니다. |
+|:---:|---|
+
+### 플랜 관리
+
+| ![플랜 관리](https://github.com/user-attachments/assets/7c491439-0b9e-442b-a327-48f9be6b6604) | 메인 페이지에서 본인의 플랜을 관리할 수 있습니다. 드래그 앤 드롭 및 카드 크기 조절을 통해 플랜을 변경할 수 있습니다. |
+|:---:|---|
+
+### 친구
+
+| ![친구 추가](https://github.com/user-attachments/assets/d82d9137-5250-443f-9013-d7877915603a) | 다른 사용자와 친구를 맺을 수 있으며, 친구의 플랜을 볼 수 있습니다. |
+|:---:|---|
+
+| ![친구 플랜 보기](https://github.com/user-attachments/assets/00890584-023c-4904-b4b7-d480729f02dd) | 친구의 플랜을 볼 수 있습니다. |
+|:---:|---|
+
+| ![댓글 작성](https://github.com/user-attachments/assets/f3cd44ea-9018-41d4-942a-8adf2bce6ba2) | 친구에게 댓글을 작성할 수 있습니다. |
+|:---:|---|
+
+---
+
+## 4. 프로젝트 구조
+
+```
+📦src
+ ┣ 📂main
+ ┃ ┣ 📂java
+ ┃ ┃ ┗ 📂com
+ ┃ ┃ ┃ ┗ 📂splanet
+ ┃ ┃ ┃ ┃ ┗ 📂splanet
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂comment
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜CommentApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜CommentRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜Comment.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂config
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FirebaseConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜OpenAiConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜RedisConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜SecurityConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜SwaggerConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜WebSocketConfig.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂core
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂exception
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜BusinessException.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜ErrorCode.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜ErrorResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜GlobalExceptionHandler.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜ResponseConstants.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂fcm
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FCMInitializer.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂handler
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SpeechWebSocketHandler.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂properties
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜ClovaProperties.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜GptProperties.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜JwtProperties.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜OAuth2Properties.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂util
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜QueryPerformanceService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜BaseEntity.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂friend
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FriendApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜Friend.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂friendRequest
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FriendRequestApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRequestController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FriendRequestCreateRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜ReceivedFriendRequestResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜SentFriendRequestResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SuccessResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRequestRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRequestService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂gpt
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜GptApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜GptController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜GptPlanSaveController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜DeviceIdGenerator.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜GptPlanSaveService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜GptService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜GptRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂jwt
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TokenApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TokenController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜RefreshToken.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜RefreshTokenRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TokenService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜JwtAuthenticationFilter.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜JwtTokenProvider.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂notification
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmTokenApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmTokenController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜NotificationController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmTokenRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FcmTokenUpdateRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmToken.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜NotificationLog.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmTokenRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜NotificationLogRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂scheduler
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜NotificationScheduler.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FcmTokenService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜NotificationService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂oauth
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜CustomOAuth2UserService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜OAuth2AuthenticationSuccessHandler.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂payment
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PaymentApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PaymentController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PaymentRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PaymentResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜Payment.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PaymentRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PaymentService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂plan
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanRequestDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanResponseDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜Plan.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂mapper
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanMapper.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂previewplan
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PreviewPlanApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PreviewPlanController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanCardRequestDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanCardResponseDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanGroupRequestDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanGroupWithCardsResponseDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanCard.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanGroup.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PreviewPlan.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanCardRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜PlanGroupRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PreviewPlanRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PreviewPlanService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂stt
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜ClovaSpeechGrpcService.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜ClovaSpeechService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂subscription
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜SubscriptionApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SubscriptionController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜SubscriptionRequest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SubscriptionResponse.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜Subscription.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SubscriptionRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜SubscriptionService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂team
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamInvitationDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamMemberDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜InvitationStatus.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜Team.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamInvitation.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamUserRelation.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserTeamRole.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamInvitationRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamUserRelationRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂teamplan
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamPlanApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlanController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜TeamPlanRequestDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlanResponseDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlan.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂mapper
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlanMapper.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlanRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamPlanService.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂user
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜UserApi.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserController.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dto
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜UserDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜UserResponseDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserUpdateRequestDto.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜User.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂repository
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserRepository.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserService.java
+ ┃ ┃ ┃ ┃ ┃ ┗ 📜SplanetApplication.java
+ ┃ ┣ 📂proto
+ ┃ ┃ ┗ 📜nest.proto
+ ┃ ┣ 📂resources
+ ┃ ┃ ┣ 📂static
+ ┃ ┃ ┣ 📜.DS_Store
+ ┃ ┃ ┣ 📜application-local.yml
+ ┃ ┃ ┣ 📜application-prod.yml
+ ┃ ┃ ┣ 📜application.yml
+ ┃ ┃ ┣ 📜env.properties
+ ┃ ┃ ┗ 📜splanet-firebase.json
+ ┃ ┗ 📜.DS_Store
+ ┣ 📂test
+ ┃ ┣ 📂java
+ ┃ ┃ ┗ 📂com
+ ┃ ┃ ┃ ┗ 📂splanet
+ ┃ ┃ ┃ ┃ ┗ 📂splanet
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂comment
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentTest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜CommentServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂friend
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂friendRequest
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜FriendRequestServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂payment
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PaymentServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂plan
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂entity
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanTest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PlanServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂previewplan
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜PreviewPlanServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂team
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜TeamServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┣ 📂user
+ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜UserControllerAcceptanceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserControllerIntegrationTest.java
+ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂service
+ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📜UserServiceTest.java
+ ┃ ┃ ┃ ┃ ┃ ┗ 📜SplanetApplicationTests.java
+ ┃ ┗ 📂resources
+ ┃ ┃ ┣ 📜application-test.yml
+ ┃ ┃ ┗ 📜application.yml
+ ┗ 📜.DS_Store
+```
+
+
+# 7. 개발 관련
+[웹 푸시 알림 - 스케줄링 쿼리 해소](https://kanguk-room.notion.site/12c036cad7a88073b0a0e1098775c723?pvs=4)
+[CLOVA Speech 실시간 스트리밍](https://kanguk-room.notion.site/STT-CLOVA-Speech-API-123036cad7a88098b644c957f8420080?pvs=4)
+[Redis 사용](https://medium.com/@kanguk.ku/redis-%EC%82%AC%EC%9A%A9%EA%B8%B0-4fd3695ab0c7)
+[무중단 배포](https://kanguk-room.notion.site/132036cad7a880e68d7bd8846b25f8a6?pvs=4)
+

--- a/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
+++ b/src/main/java/com/splanet/splanet/core/exception/ErrorCode.java
@@ -48,7 +48,10 @@ public enum ErrorCode {
     SELF_FRIEND_REQUEST_NOT_ALLOWED("본인에게 친구요청을 보낼 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     // redis
-    REDIS_SCAN_FAILED("Redis 키 스캔 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+    REDIS_SCAN_FAILED("Redis 키 스캔 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+
+    INVALID_PLAN_FORMAT("", HttpStatus.BAD_REQUEST);
+
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/splanet/splanet/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/splanet/splanet/core/exception/GlobalExceptionHandler.java
@@ -14,7 +14,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
         ErrorCode errorCode = ex.getErrorCode();
-        ErrorResponse response = new ErrorResponse(errorCode.getMessage(), errorCode.getStatus().value());
+
+        String message = errorCode == ErrorCode.INVALID_PLAN_FORMAT ? ex.getMessage() : errorCode.getMessage();
+        ErrorResponse response = new ErrorResponse(message, errorCode.getStatus().value());
+
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 

--- a/src/main/java/com/splanet/splanet/core/exception/InvalidPlanFormatException.java
+++ b/src/main/java/com/splanet/splanet/core/exception/InvalidPlanFormatException.java
@@ -1,0 +1,8 @@
+package com.splanet.splanet.core.exception;
+
+public class InvalidPlanFormatException extends BusinessException {
+
+    public InvalidPlanFormatException(String messageContent) {
+        super(ErrorCode.INVALID_PLAN_FORMAT, messageContent);
+    }
+}

--- a/src/main/java/com/splanet/splanet/gpt/controller/GptApi.java
+++ b/src/main/java/com/splanet/splanet/gpt/controller/GptApi.java
@@ -10,28 +10,66 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
-@Tag(name = "GPT", description = "GPT 연결 관련 API")
+@Tag(name = "GPT", description = "GPT 관련 API")
 @RequestMapping("/api/gpt")
 public interface GptApi {
 
-    @PostMapping("/trial")
-    @Operation(summary = "GPT 요청 보내기 - 비회원", description = "비회원의 GPT 요청을 처리합니다.")
+    @PostMapping("/trial/strong")
+    @Operation(summary = "강 레벨 GPT 요청 보내기 - 비회원", description = "비회원의 강 레벨 GPT 요청을 처리합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
     })
-    ResponseEntity<String> callGptForTrial(@RequestBody GptRequest gptRequest, @RequestParam String deviceId);
+    ResponseEntity<String> callGptForTrialStrong(@RequestBody GptRequest gptRequest, @RequestParam String deviceId);
 
-    @PostMapping("/member")
-    @Operation(summary = "GPT 요청 보내기 - 회원", description = "회원의 GPT 요청을 처리합니다.")
+    @PostMapping("/trial/moderate")
+    @Operation(summary = "중 레벨 GPT 요청 보내기 - 비회원", description = "비회원의 중 레벨 GPT 요청을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+    })
+    ResponseEntity<String> callGptForTrialModerate(@RequestBody GptRequest gptRequest, @RequestParam String deviceId);
+
+    @PostMapping("/trial/light")
+    @Operation(summary = "약 레벨 GPT 요청 보내기 - 비회원", description = "비회원의 약 레벨 GPT 요청을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+    })
+    ResponseEntity<String> callGptForTrialLight(@RequestBody GptRequest gptRequest, @RequestParam String deviceId);
+
+    @PostMapping("/member/strong")
+    @Operation(summary = "강 레벨 GPT 요청 보내기 - 회원", description = "회원의 강 레벨 GPT 요청을 처리합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
     })
-    ResponseEntity<String> callGptForMember(@RequestBody GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId);
+    ResponseEntity<String> callGptForMemberStrong(@RequestBody GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId);
+
+    @PostMapping("/member/moderate")
+    @Operation(summary = "중 레벨 GPT 요청 보내기 - 회원", description = "회원의 중 레벨 GPT 요청을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+    })
+    ResponseEntity<String> callGptForMemberModerate(@RequestBody GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId);
+
+    @PostMapping("/member/light")
+    @Operation(summary = "약 레벨 GPT 요청 보내기 - 회원", description = "회원의 약 레벨 GPT 요청을 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유효한 응답을 성공적으로 가져왔습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content)
+    })
+    ResponseEntity<String> callGptForMemberLight(@RequestBody GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId);
 
     @GetMapping("/generate-device-id")
     @Operation(summary = "새로운 Device ID 생성", description = "새로운 deviceId를 생성하여 반환합니다.")

--- a/src/main/java/com/splanet/splanet/gpt/controller/GptController.java
+++ b/src/main/java/com/splanet/splanet/gpt/controller/GptController.java
@@ -5,7 +5,8 @@ import com.splanet.splanet.gpt.service.DeviceIdGenerator;
 import com.splanet.splanet.gpt.service.GptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,17 +17,40 @@ public class GptController implements GptApi {
     private final GptService gptService;
 
     @Override
-    public ResponseEntity<String> callGptForTrial(GptRequest gptRequest, @RequestParam String deviceId) {
-        String jsonResponse = gptService.generateResponse(gptRequest.getText(), null, deviceId); // 비회원 호출
-        return ResponseEntity.ok(jsonResponse);
+    public ResponseEntity<String> callGptForTrialStrong(GptRequest gptRequest, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForStrong(gptRequest.getText(), null, deviceId);
+        return ResponseEntity.ok(response);
     }
 
     @Override
-    public ResponseEntity<String> callGptForMember(GptRequest gptRequest, Long userId, @RequestParam String deviceId) {
-        String jsonResponse = gptService.generateResponse(gptRequest.getText(), userId, deviceId); // 회원 호출
-        return ResponseEntity.ok(jsonResponse);
+    public ResponseEntity<String> callGptForTrialModerate(GptRequest gptRequest, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForModerate(gptRequest.getText(), null, deviceId);
+        return ResponseEntity.ok(response);
     }
 
+    @Override
+    public ResponseEntity<String> callGptForTrialLight(GptRequest gptRequest, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForLight(gptRequest.getText(), null, deviceId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<String> callGptForMemberStrong(GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForStrong(gptRequest.getText(), userId, deviceId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<String> callGptForMemberModerate(GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForModerate(gptRequest.getText(), userId, deviceId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<String> callGptForMemberLight(GptRequest gptRequest, @AuthenticationPrincipal Long userId, @RequestParam String deviceId) {
+        String response = gptService.generateResponseForLight(gptRequest.getText(), userId, deviceId);
+        return ResponseEntity.ok(response);
+    }
 
     @Override
     public ResponseEntity<String> generateDeviceId() {

--- a/src/main/java/com/splanet/splanet/gpt/controller/GptPlanSaveController.java
+++ b/src/main/java/com/splanet/splanet/gpt/controller/GptPlanSaveController.java
@@ -2,12 +2,14 @@ package com.splanet.splanet.gpt.controller;
 
 import com.splanet.splanet.previewplan.dto.PlanGroupRequestDto;
 import com.splanet.splanet.gpt.service.GptPlanSaveService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/gpt/plan")
+@Tag(name = "GPT-Plan save", description = "GPT로 생성된 플랜을 저장한다.")
 @RequiredArgsConstructor
 public class GptPlanSaveController {
 

--- a/src/main/java/com/splanet/splanet/gpt/controller/GptPlanSaveController.java
+++ b/src/main/java/com/splanet/splanet/gpt/controller/GptPlanSaveController.java
@@ -1,6 +1,5 @@
 package com.splanet.splanet.gpt.controller;
 
-import com.splanet.splanet.previewplan.dto.PlanGroupRequestDto;
 import com.splanet.splanet.gpt.service.GptPlanSaveService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +15,8 @@ public class GptPlanSaveController {
     private final GptPlanSaveService gptPlanSaveService;
 
     @PostMapping("/save")
-    public ResponseEntity<Void> saveGptResponsePlans(@RequestBody PlanGroupRequestDto planGroupRequestDto) {
-        gptPlanSaveService.saveGptResponsePlans(planGroupRequestDto);
+    public ResponseEntity<Void> saveGptResponsePlans(@RequestBody String planGroupResponse) {
+        gptPlanSaveService.saveGptResponsePlans(planGroupResponse); // JSON 파싱 및 저장 수행
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/splanet/splanet/gpt/service/GptPlanSaveService.java
+++ b/src/main/java/com/splanet/splanet/gpt/service/GptPlanSaveService.java
@@ -15,6 +15,8 @@ public class GptPlanSaveService {
     public void saveGptResponsePlans(PlanGroupRequestDto planGroupRequestDto) {
         String deviceId = planGroupRequestDto.deviceId();
         String groupId = planGroupRequestDto.groupId();
+        
+        previewPlanService.deleteAllPreviewPlansByDeviceId(deviceId);
 
         // JSON 응답에서 planCards 리스트를 순회하며 개별 PlanCard를 저장
         for (PlanCardRequestDto planCardRequestDto : planGroupRequestDto.planCards()) {

--- a/src/main/java/com/splanet/splanet/gpt/service/GptPlanSaveService.java
+++ b/src/main/java/com/splanet/splanet/gpt/service/GptPlanSaveService.java
@@ -1,6 +1,8 @@
 package com.splanet.splanet.gpt.service;
 
-import com.splanet.splanet.previewplan.dto.PlanCardRequestDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.splanet.splanet.core.exception.InvalidPlanFormatException;
 import com.splanet.splanet.previewplan.dto.PlanGroupRequestDto;
 import com.splanet.splanet.previewplan.service.PreviewPlanService;
 import lombok.RequiredArgsConstructor;
@@ -11,16 +13,26 @@ import org.springframework.stereotype.Service;
 public class GptPlanSaveService {
 
     private final PreviewPlanService previewPlanService;
+    private final ObjectMapper objectMapper;
 
-    public void saveGptResponsePlans(PlanGroupRequestDto planGroupRequestDto) {
+    public void saveGptResponsePlans(String responseContent) {
+        PlanGroupRequestDto planGroupRequestDto = parsePlanGroupRequestDto(responseContent);
+
         String deviceId = planGroupRequestDto.deviceId();
         String groupId = planGroupRequestDto.groupId();
-        
+
         previewPlanService.deleteAllPreviewPlansByDeviceId(deviceId);
 
-        // JSON 응답에서 planCards 리스트를 순회하며 개별 PlanCard를 저장
-        for (PlanCardRequestDto planCardRequestDto : planGroupRequestDto.planCards()) {
+        for (var planCardRequestDto : planGroupRequestDto.planCards()) {
             previewPlanService.savePlanCard(deviceId, groupId, planCardRequestDto);
+        }
+    }
+
+    private PlanGroupRequestDto parsePlanGroupRequestDto(String responseContent) {
+        try {
+            return objectMapper.readValue(responseContent, PlanGroupRequestDto.class);
+        } catch (JsonProcessingException e) {
+            throw new InvalidPlanFormatException(responseContent); // JSON 형식이 아닐 경우 예외 발생
         }
     }
 }

--- a/src/main/java/com/splanet/splanet/gpt/service/GptService.java
+++ b/src/main/java/com/splanet/splanet/gpt/service/GptService.java
@@ -23,10 +23,12 @@ public class GptService {
     private final ObjectMapper objectMapper;
 
     private static final double RESPONSE_TEMPERATURE = 0.8;
-    private static final String PROMPT_TEMPLATE_MEMBER =
-            "사용자 입력: \"%s\" (deviceId: %s) 기존 일정이 있다면 해당 시간과는 겹치지 않게 해 줘 기존일정:%s 현재 시간 이후로 가능한 다른 시간에 일정을 세워줘 (%s 기준). 모든 일정은 한국 시간(UTC+9)을 기준으로 설정해줘.";
-    private static final String PROMPT_TEMPLATE_TRIAL =
-            "사용자 입력: \"%s\" (deviceId: %s) 현재 시간 이후로 가능한 다른 시간에 일정을 세워줘 (%s 기준). 모든 일정은 한국 시간(UTC+9)을 기준으로 설정해줘.";
+    private static final String PROMPT_TEMPLATE_STRONG =
+            "사용자 입력: \"%s\" (deviceId: %s) (groupId: %s) 기존 일정이 있다면 해당 시간과는 겹치지 않게 해 줘 기존일정:%s 현재 시간 이후로 가능한 자주 반복하여 짧고 집중적으로 일정을 완수할 수 있도록 계획을 세워줘. 시험이 포함된 경우, 시험 당일이 아닌 전날까지 준비가 완료되도록 해줘 (%s 기준). 모든 일정은 한국 시간(UTC+9)을 기준으로 설정해줘.";
+    private static final String PROMPT_TEMPLATE_MODERATE =
+            "사용자 입력: \"%s\" (deviceId: %s) (groupId: %s) 기존 일정이 있다면 해당 시간과는 겹치지 않게 해 줘 기존일정:%s 현재 시간 이후로 적당한 간격을 두고 모든 일정을 완수할 수 있도록 계획해줘. 시험이 포함된 경우, 시험 당일이 아닌 전날까지 준비가 완료되도록 해줘 (%s 기준). 모든 일정은 한국 시간(UTC+9)을 기준으로 설정해줘.";
+    private static final String PROMPT_TEMPLATE_LIGHT =
+            "사용자 입력: \"%s\" (deviceId: %s) (groupId: %s) 기존 일정이 있다면 해당 시간과는 겹치지 않게 해 줘 기존일정:%s 현재 시간 이후로 여유 있게 모든 일정을 완수할 수 있도록 계획해줘. 시험이 포함된 경우, 시험 당일이 아닌 전날까지 준비가 완료되도록 해줘 (%s 기준). 모든 일정은 한국 시간(UTC+9)을 기준으로 설정해줘.";
 
     public GptService(OpenAiApi openAiApi, GptProperties gptProperties, PlanService planService, ObjectMapper objectMapper) {
         this.openAiApi = openAiApi;
@@ -35,23 +37,29 @@ public class GptService {
         this.objectMapper = objectMapper;
     }
 
-    public String generateResponse(String userInput, Long userId, String deviceId) {
-        String fullPrompt = createPrompt(userInput, userId, deviceId);
+    public String generateResponseForStrong(String userInput, Long userId, String deviceId) {
+        return generateResponse(userInput, userId, deviceId, PROMPT_TEMPLATE_STRONG, 3);
+    }
+
+    public String generateResponseForModerate(String userInput, Long userId, String deviceId) {
+        return generateResponse(userInput, userId, deviceId, PROMPT_TEMPLATE_MODERATE, 2);
+    }
+
+    public String generateResponseForLight(String userInput, Long userId, String deviceId) {
+        return generateResponse(userInput, userId, deviceId, PROMPT_TEMPLATE_LIGHT, 1);
+    }
+
+    private String generateResponse(String userInput, Long userId, String deviceId, String promptTemplate, int groupId) {
+        String currentTime = getCurrentTime();
+        List<PlanResponseDto> futurePlans = (userId != null) ? planService.getAllFuturePlansByUserId(userId) : List.of();
+        String planJson = convertPlansToJson(futurePlans);
+        String fullPrompt = String.format(promptTemplate, userInput, deviceId, groupId, planJson, currentTime);
+        System.out.println(fullPrompt);
+
         OpenAiApi.ChatCompletionMessage userMessage = createUserMessage(fullPrompt);
         OpenAiApi.ChatCompletionRequest chatRequest = createChatRequest(userMessage);
 
         return getGptResponse(chatRequest);
-    }
-
-    private String createPrompt(String userInput, Long userId, String deviceId) {
-        String currentTime = getCurrentTime();
-        if (userId != null) {
-            List<PlanResponseDto> futurePlans = planService.getAllFuturePlansByUserId(userId);
-            String planJson = convertPlansToJson(futurePlans);
-            return String.format(PROMPT_TEMPLATE_MEMBER, userInput, deviceId, planJson, currentTime);
-        } else {
-            return String.format(PROMPT_TEMPLATE_TRIAL, userInput, deviceId, currentTime);
-        }
     }
 
     private String getCurrentTime() {

--- a/src/main/java/com/splanet/splanet/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/splanet/splanet/jwt/JwtAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private boolean isExemptedPath(String requestURI) {
-    return requestURI.equals("/api/users/create") || requestURI.startsWith("/api/token") || requestURI.startsWith("/api/stt") || requestURI.equals("/api/gpt/trial") || requestURI.equals("/api/gpt/generate-device-id") || requestURI.equals("/api/gpt/plan/save") || requestURI.startsWith("/api/notification");
+    return requestURI.equals("/api/users/create") || requestURI.startsWith("/api/token")  || requestURI.startsWith("/api/preview-plan") || requestURI.startsWith("/api/stt") || requestURI.startsWith("/api/gpt/trial") || requestURI.equals("/api/gpt/generate-device-id") || requestURI.equals("/api/gpt/plan/save") || requestURI.startsWith("/api/notification");
   }
 
   private void sendErrorResponse(HttpServletResponse response, int status, String message) throws IOException {

--- a/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanApi.java
+++ b/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanApi.java
@@ -77,4 +77,14 @@ public interface PreviewPlanApi {
     })
     ResponseEntity<Set<PlanGroupWithCardsResponseDto>> getPreviewPlans(
             @Parameter(description = "조회할 디바이스 ID", required = true) @RequestParam String deviceId);
+
+    @DeleteMapping("/delete-all")
+    @Operation(summary = "모든 임시 플랜 삭제", description = "특정 deviceId에 해당하는 모든 임시 플랜을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모든 임시 플랜이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 deviceId에 해당하는 임시 플랜이 존재하지 않습니다.", content = @Content)
+    })
+    ResponseEntity<Void> deleteAllPreviewPlansByDeviceId(
+            @Parameter(description = "삭제할 deviceId", required = true) @RequestParam String deviceId);
+
 }

--- a/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanController.java
+++ b/src/main/java/com/splanet/splanet/previewplan/controller/PreviewPlanController.java
@@ -41,6 +41,12 @@ public class PreviewPlanController implements PreviewPlanApi {
     }
 
     @Override
+    public ResponseEntity<Void> deleteAllPreviewPlansByDeviceId(String deviceId) {
+        previewPlanService.deleteAllPreviewPlansByDeviceId(deviceId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
     public ResponseEntity<Set<PlanGroupWithCardsResponseDto>> getPreviewPlans(String deviceId) {
         Set<PlanGroupWithCardsResponseDto> previewPlans = previewPlanService.getPreviewPlans(deviceId);
         return ResponseEntity.ok(previewPlans);

--- a/src/main/java/com/splanet/splanet/previewplan/service/PreviewPlanService.java
+++ b/src/main/java/com/splanet/splanet/previewplan/service/PreviewPlanService.java
@@ -69,6 +69,19 @@ public class PreviewPlanService {
         updatePlanGroup(deviceId, groupId, cardId, false);
     }
 
+    public void deleteAllPreviewPlansByDeviceId(String deviceId) {
+        Set<String> groupKeys = scanKeysByPattern(PLAN_GROUP_PREFIX + deviceId + ":*");
+
+        for (String groupKey : groupKeys) {
+            String groupId = extractGroupIdFromKey(groupKey);
+
+            Set<String> cardKeys = scanKeysByPattern(PLAN_CARD_PREFIX + deviceId + ":" + groupId + ":*");
+            cardKeys.forEach(redisTemplate::delete);
+
+            redisTemplate.delete(groupKey);
+        }
+    }
+
     public Set<PlanGroupWithCardsResponseDto> getPreviewPlans(String deviceId) {
         Set<String> groupKeys = scanKeysByPattern(PLAN_GROUP_PREFIX + deviceId + ":*");
 


### PR DESCRIPTION
## 📄요약

> GPT 프롬프팅에 따라 상,중,하 로 구분하여 API 3개를 만들고, 저장할 때 임시 데이터를 삭제하도록 한다. 

## 🖋️작업 내용

- [ ] GPT 프롬프팅에 따라 상,중,하 로 구분하여 API 3개 만들기
- [ ] 저장할 때 임시 데이터를 삭제
- [ ] 잘못된 입력 값 처리 로직 추가

## 📷스크린샷
![image](https://github.com/user-attachments/assets/9abf2d16-752b-46bb-ade7-a1bc3c80ec1e)


## ❗참고 사항


## 🔗이슈
close #이슈번호
