### PR TITLE
[refactor]: 웹소켓 허용 경로 제한

### DIFF
--- a/src/main/java/com/splanet/splanet/config/WebSocketConfig.java
+++ b/src/main/java/com/splanet/splanet/config/WebSocketConfig.java
@@ -19,6 +19,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(speechWebSocketHandler, "/ws/stt")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins("http://localhost:5173", "https://www.splanet.co.kr");
     }
 }


### PR DESCRIPTION
우리 서버만 허용하도록 한다.

## 📄요약

> 웹소켓 외부 요청 경로를 제한한다. 

## 🖋️작업 내용

- [ ] WebSocketConfig 수정

## 📷스크린샷


## ❗참고 사항


## 🔗이슈
close #이슈번호
